### PR TITLE
1D to 2D output for data that used "mask_from_dataset" during training

### DIFF
--- a/bris/outputs/netcdf.py
+++ b/bris/outputs/netcdf.py
@@ -75,9 +75,11 @@ class Netcdf(Output):
         if self._is_masked:
             # If a mask was used during training:
             # Compute 1D->2D index to output 2D arrays by using a mask file
-            self.ds_mask = xr.open_dataset(mask_file,drop_variables=['time', 'projection_stere'])
-            # TODO check if mask has time dimension before using isel
-            mask = self.ds_mask.isel(time=0)[mask_field].values
+            self.ds_mask = xr.open_dataset(mask_file)
+            if 'time' in self.ds_mask.dims:
+                mask = self.ds_mask.isel(time=0)[mask_field].values
+            else:
+                mask = self.ds_mask[mask_field].values
             ind = np.arange(np.size(mask)).reshape(np.shape(mask))
             # Assume mask==1 where have values
             self.indices_1D_to_2D = ind[mask==1.0] 

--- a/bris/outputs/netcdf.py
+++ b/bris/outputs/netcdf.py
@@ -72,33 +72,18 @@ class Netcdf(Output):
             self.proj4_str = proj4_str
 
         if self._use_template:
-            # If use the mask file as template, we can drop the land_binary_mask 
-            # that may have a long time dimension when loading data
-            self.ds_template = xr.open_dataset(template_file,drop_variables=['lon','X','Y','time','land_binary_mask','projection_stere'])
-            
             # Compute 1D->2D index to output 2D arrays
+            # Drop variables like land_binary_mask that may have a long time dimension
+            self.ds_template = xr.open_dataset(template_file,drop_variables=['land_binary_mask', 'time', 'projection_stere'])
             lat_full = self.ds_template.lat.values
             lat = self.pm.lats
-            # Define a tolerance level for numerical differences
-            tolerance = 1e-6
 
-            # Initialize an indices array
-            ind = []
-            
-            # Iterate over lat_full and store the index of lat_full 
-            # that are has a value close (within tolerance) to any value in lat
-            # TODO: this loop takes very long...
-            n = 0
-            for i in range(lat_full.shape[0]):
-                for j in range(lat_full.shape[1]):
-                    diff = np.abs(lat_full[i, j] - lat)
-                    min_diff_index = np.argmin(diff) # should only return one value...
-                    if diff[min_diff_index] < tolerance:
-                        ind.append(n)
-                    if n%10000==0: print("----- n= , len(ind)= ",n,len(ind))
-                    n += 1
-            # the finished index array to map from 1D to 2D
-            self.indices_1D_to_2D = np.array(ind)
+            # Rounding to significant digits before comparing since lat_full and lat
+            # might not be numerically identical as np.isin assumes
+            dec = 5
+            mask = np.isin(np.round(lat_full,dec), np.round(self.pm.lats,dec))
+            ind = np.arange(np.size(lat_full)).reshape(np.shape(lat_full))
+            self.indices_1D_to_2D = ind[mask] 
             print("----len compare",len(self.indices_1D_to_2D),len(lat))
             print("------shape:", self.indices_1D_to_2D.shape )   
             
@@ -266,12 +251,10 @@ class Netcdf(Output):
             if self._use_template:
                 self.ds[c("latitude")] = (
                     spatial_dims,
-                    #self.pm.lats,
                     self.ds_template.lat.values,
                 )
                 self.ds[c("longitude")] = (
                     spatial_dims,
-                    #self.pm.lons,
                     self.ds_template.lon.values,
                 )
 

--- a/bris/outputs/netcdf.py
+++ b/bris/outputs/netcdf.py
@@ -254,6 +254,16 @@ class Netcdf(Output):
                     spatial_dims,
                     self.ds_mask.lon.values,
                 )
+                if self.pm.altitudes is not None:
+                    altitudes_rec = np.nan * np.zeros(
+                        [len(times), len(y), len(x), self.pm.num_members], np.float32
+                    )
+                    # Reconstruct the 2D array 
+                    altitudes_rec[:, :, :, :].flat[self.indices_1D_to_2D] = self.pm.altitudes
+                    self.ds[c("surface_altitude")] = (
+                        spatial_dims,
+                        altitudes_rec
+                        )
 
             else: 
                 self.ds[c("latitude")] = (
@@ -264,11 +274,11 @@ class Netcdf(Output):
                     spatial_dims,
                     self.pm.lons,
                 )
-            if self.pm.altitudes is not None:
-                self.ds[c("surface_altitude")] = (
-                    spatial_dims,
-                    self.pm.altitudes
-                )
+                if self.pm.altitudes is not None:
+                    self.ds[c("surface_altitude")] = (
+                        spatial_dims,
+                        self.pm.altitudes
+                    )
 
         for cfname in [
             "forecast_reference_time",

--- a/bris/outputs/netcdf.py
+++ b/bris/outputs/netcdf.py
@@ -83,7 +83,7 @@ class Netcdf(Output):
             self.indices_1D_to_2D = ind[mask] 
             # TODO: the np.isin() method above is not safe if the values of lon or lat 
             # have been modified due to precision etc.. should use nearest neighbour search instead
-            # TODO: also do sanity checks on the template file? 
+            # TODO: also do sanity checks on the template file? eg test if the dimension is larger than original?
             
     def _add_forecast(self, times: list, ensemble_member: int, pred: np.array):
         if self.pm.num_members > 1:


### PR DESCRIPTION
Changes should not affect the output unless the new arguments are given. 

Changes include:
- adding two new arguments for the `netcdf` output option: `mask_file` and `mask_field`, which is the file that we would like to read the mask from, and the field name, respectively. Similar to the args that `feature/trimedge` [branch](https://github.com/metno/anemoi-datasets/tree/feature/trimedge) takes. 
- added a new property `_is_masked` which returns true if the file `mask_file` has been provided as input. 
- opens the mask file and uses the mask to rebroadcast the 1D output to the original 2D grid
- uses the grid from the mask file when writing output (e.g. `X`, `Y`, `lon`, `lat` instead of `self.pm.lats` and so on). 

Let me know if you want me to implement it differently or do some other changes. 