### PR TITLE
Update netcdf.py to use a mask file to map 1D to 2D

### DIFF
--- a/bris/outputs/netcdf.py
+++ b/bris/outputs/netcdf.py
@@ -36,6 +36,8 @@ class Netcdf(Output):
         extra_variables=list(),
         proj4_str=None,
         domain_name=None,
+        mask_file=None,
+        mask_field=None,
     ):
         """
         Args:
@@ -63,12 +65,25 @@ class Netcdf(Output):
         self.interp_res = interp_res
         self.latrange = latrange
         self.lonrange = lonrange
+        self.mask_file = mask_file
 
         if domain_name is not None:
             self.proj4_str = projections.get_proj4_str(domain_name)
         else:
             self.proj4_str = proj4_str
 
+        if self._is_masked:
+            # If a mask was used during training:
+            # Compute 1D->2D index to output 2D arrays by using a mask file
+            self.ds_mask = xr.open_dataset(mask_file)
+            if 'time' in self.ds_mask.dims:
+                mask = self.ds_mask.isel(time=0)[mask_field].values
+            else:
+                mask = self.ds_mask[mask_field].values
+            ind = np.arange(np.size(mask)).reshape(np.shape(mask))
+            # Assume mask==1 where have values
+            self.indices_1D_to_2D = ind[mask==1.0] 
+            
     def _add_forecast(self, times: list, ensemble_member: int, pred: np.array):
         if self.pm.num_members > 1:
             # Cache data with intermediate
@@ -86,6 +101,11 @@ class Netcdf(Output):
 
     def get_filename(self, forecast_reference_time):
         return utils.expand_time_tokens(self.filename_pattern, forecast_reference_time)
+
+    @property
+    def _is_masked(self):
+        """Was a mask_from_dataset applied during training?"""
+        return self.mask_file is not None
 
     @property
     def _is_gridded(self):
@@ -157,9 +177,17 @@ class Netcdf(Output):
             coords[y_dim_name] = y
             spatial_dims = (y_dim_name, x_dim_name)
         else:
-            y = np.arange(len(self.pm.lats)).astype(np.int32)
-            coords["location"] = y
-            spatial_dims = ("location",)
+            if self._is_masked:
+                # Use the template to get the (full) grid
+                x    = self.ds_mask.X.values
+                y    = self.ds_mask.Y.values
+                x_dim_name = c("projection_x_coordinate")
+                y_dim_name = c("projection_y_coordinate")
+                spatial_dims = (y_dim_name, x_dim_name)
+            else:
+                y = np.arange(len(self.pm.lats)).astype(np.int32)
+                coords["location"] = y
+                spatial_dims = ("location",)
 
         if self.pm.num_members > 1:
             coords[c("realization")] = np.arange(self.pm.num_members).astype(np.int32)
@@ -217,19 +245,40 @@ class Netcdf(Output):
                     # proj_attrs["earth_radius"] = 6371000.0
                 self.ds[c("projection")] = ([], 0, proj_attrs)
         else:
-            self.ds[c("latitude")] = (
-                spatial_dims,
-                self.pm.lats,
-            )
-            self.ds[c("longitude")] = (
-                spatial_dims,
-                self.pm.lons,
-            )
-            if self.pm.altitudes is not None:
-                self.ds[c("surface_altitude")] = (
+            if self._is_masked:
+                self.ds[c("latitude")] = (
                     spatial_dims,
-                    self.pm.altitudes
+                    self.ds_mask.lat.values,
                 )
+                self.ds[c("longitude")] = (
+                    spatial_dims,
+                    self.ds_mask.lon.values,
+                )
+                if self.pm.altitudes is not None:
+                    altitudes_rec = np.nan * np.zeros(
+                        [len(times), len(y), len(x), self.pm.num_members], np.float32
+                    )
+                    # Reconstruct the 2D array 
+                    altitudes_rec[:, :, :, :].flat[self.indices_1D_to_2D] = self.pm.altitudes
+                    self.ds[c("surface_altitude")] = (
+                        spatial_dims,
+                        altitudes_rec
+                        )
+
+            else: 
+                self.ds[c("latitude")] = (
+                    spatial_dims,
+                    self.pm.lats,
+                )
+                self.ds[c("longitude")] = (
+                    spatial_dims,
+                    self.pm.lons,
+                )
+                if self.pm.altitudes is not None:
+                    self.ds[c("surface_altitude")] = (
+                        spatial_dims,
+                        self.pm.altitudes
+                    )
 
         for cfname in [
             "forecast_reference_time",
@@ -258,13 +307,13 @@ class Netcdf(Output):
                         dim_name,
                         *spatial_dims,
                     ]
-                    if self._is_gridded:
+                    if self._is_gridded or self._is_masked:
                         shape = [len(times), len(self.ds[dim_name]), len(y), len(x)]
                     else:
                         shape = [len(times), len(self.ds[dim_name]), len(y)]
                 else:
                     dims = [c("time"), *spatial_dims]
-                    if self._is_gridded:
+                    if self._is_gridded or self._is_masked:
                         shape = [len(times), len(y), len(x)]
                     else:
                         shape = [len(times), len(y)]
@@ -276,7 +325,7 @@ class Netcdf(Output):
                 ar = np.nan * np.zeros(shape, np.float32)
                 self.ds[ncname] = (dims, ar)
 
-            if self._is_gridded:
+            if self._is_gridded or self._is_masked:
                 shape = [len(times), len(y), len(x), self.pm.num_members]
             else:
                 shape = [len(times), len(y), self.pm.num_members]
@@ -292,6 +341,13 @@ class Netcdf(Output):
                 )
                 for i in range(self.pm.num_members):
                     ar[:, :, :, i] = gridpp.nearest(ipoints, ogrid, curr[:, :, i])
+            elif self._is_masked: 
+                curr = pred[..., variable_index, :]
+                ar = np.nan * np.zeros(
+                    [len(times), len(y), len(x), self.pm.num_members], np.float32
+                )
+                # Reconstruct the 2D array (nans where no data)
+                ar[:, :, :, :].flat[self.indices_1D_to_2D] = curr[:, :, :]
             else:
                 ar = np.reshape(pred[..., variable_index, :], shape)
 

--- a/bris/projections.py
+++ b/bris/projections.py
@@ -8,6 +8,10 @@ def get_proj4_str(name):
         return "+proj=lcc +lat_0=63.3 +lon_0=15 +lat_1=63.3 +lat_2=63.3 +x_0=0 +y_0=0 +R=6371000 +units=m +no_defs +type=crs"
     elif name == "arome_arctic":
         return "+proj=lcc +lat_0=77.5 +lon_0=-25 +lat_1=77.5 +lat_2=77.5 +x_0=0 +y_0=0 +R=6371000 +units=m +no_defs +type=crs"
+    elif name == "norkyst_v3":
+        return "+proj=stere +lat_0=90 +lat_ts=60 +lon_0=70 +x_0=3369600 +y_0=1844800 +a=6378137 +b=6356752.3142 +units=m +no_defs +type=crs"
+    elif name == "nordic_analysis":
+        return "+proj=lcc +lat_0=63.0 +lon_0=15 +lat_1=63.0 +lat_2=63.0 +x_0=0 +y_0=0 +R=6371000 +units=m +no_defs +type=crs"
 
 
 def get_xy(lats, lons, proj_str):


### PR DESCRIPTION
**Note:** this PR is identical to #34 but based on newest commits to main.

Adding functionality for data that used "mask_from_dataset" during training (`feature/trimedge` [branch](https://github.com/metno/anemoi-datasets/tree/feature/trimedge))

Changes should not affect the output unless the new arguments are given. 

Changes include:
- adding two new arguments for the `netcdf` output option: `mask_file` and `mask_field`, which is the file that we would like to read the mask from, and the field name, respectively. Similar to the args that `feature/trimedge` [branch](https://github.com/metno/anemoi-datasets/tree/feature/trimedge) takes. 
- added a new property `_is_masked` which returns true if the file `mask_file` has been provided as input. 
- opens the mask file and uses the mask to rebroadcast the 1D output to the original 2D grid
- uses the grid from the mask file when writing output (e.g. `X`, `Y`, `lon`, `lat` instead of `self.pm.lats` and so on). 

Let me know if you want me to implement it differently or do some other changes. 