### PR TITLE
Fix/remove legacy

### DIFF
--- a/bris/schema/schema.json
+++ b/bris/schema/schema.json
@@ -110,16 +110,22 @@
         },
 
         "AnemoiDatasetSource": {
-            "description": "Zarr file that can be read by anemoi-datasets",
+            "description": "Zarr dataset that can be read by anemoi-datasets",
             "type": "object",
             "properties": {
-                "dataset": {
-                    "description": "Anemoi datasets open_dataset recipie, dictionairy",
-                    "type": "object"
-                },
-                "variable": {
-                    "description": "Variable name",
-                    "type": "string"
+                "anemoidataset": {
+                    "type": "object",
+                    "properties": {
+                        "dataset": {
+                            "description": "Anemoi datasets open_dataset recipe, dictionary",
+                            "type": "object"
+                        },
+                        "variable": {
+                            "description": "Variable name",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["dataset", "variable"]
                 }
             },
             "required": ["anemoidataset"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,13 +49,6 @@ dependencies = [
     "anemoi-training>=0.1.0",
 ]
 
-# legacy version supports this branch from MetNo fork of ECMWF anemoi-models
-# contains some optimizations and fixes 
-optional-dependencies.legacy = [
-    "anemoi-models @ git+https://github.com/metno/anemoi-models.git@feature/fix-memory-inference-chunking",
-    "aifs @ git+ssh://git@github.com/metno/aifs-mono.git@production",
-]
-
 optional-dependencies.tests = [
     "tox",
 ]


### PR DESCRIPTION
Check instructions for installing with legacy support: https://github.com/metno/bris-inference/wiki/AIFS-mono-support