### PR TITLE
19 graph switch

### DIFF
--- a/bris/__main__.py
+++ b/bris/__main__.py
@@ -32,9 +32,11 @@ def main():
     checkpoint.set_encoder_decoder_num_chunks(
         getattr(config, "inference_num_chunks", 1)
     )
-    if hasattr(config.model, "graph"):
+    if hasattr(config, "graph"):
         LOGGER.info("Update graph is enabled. Proceeding to change internal graph")
-        checkpoint.update_graph(config.model.graph)  # Pass in a new graph if needed
+        # At the moment config.graph is only a POSIX path.
+        # TODO: In future a graph can be generated "on the fly" by providing a config 
+        checkpoint.update_graph(config.graph)  # Pass in a new graph if needed
 
     # Get timestep from checkpoint. Also store a version in seconds for local use.
     config.timestep = None

--- a/bris/checkpoint.py
+++ b/bris/checkpoint.py
@@ -166,29 +166,34 @@ class Checkpoint:
                 ), f"Cannot locate graph file. Got path: {path}"
                 external_graph = torch.load(path, map_location="cpu")
                 LOGGER.info("Loaded external graph from path")
-                try:
-                    _STATE = self._model_state
-                    self._model_instance.graph_data = external_graph
-                    LOGGER.info("Rebuilding layers to support new graph")
-                    self._model_instance._build_model()
-                    self.UPDATE_GRAPH = True
-                    LOGGER.info(
-                        "Successfully changed internal graph with external graph!"
-                    )
+                
+                #try:
+                _STATE = self._model_state
+                
+                #conf = DotDict(self._model_instance.data_indices.config)
+                self._model_instance.graph_data = external_graph
+                self._model_instance.config = self.confing #conf 
 
-                    for layer_name, param in self._model_instance.model:
-                        param.data = _STATE[layer_name]
+                LOGGER.info("Rebuilding layers to support new graph")
+                self._model_instance._build_model()
+                self.UPDATE_GRAPH = True
+                LOGGER.info(
+                    "Successfully changed internal graph with external graph!"
+                )
 
-                    return self._model_instance.graph_data
+                for layer_name, param in self._model_instance.model:
+                    param.data = _STATE[layer_name]
 
-            except Exception as e:
-                raise e  # RuntimeError("Failed to update the graph.") from e
-        else:
-            # future implementation
-            # _graph = anemoi.graphs.create() <-- skeleton
-            # self._model_instance.graph_data = _graph <- update graph obj within inst
-            # return _graph <- return graph
-            raise NotImplementedError
+                return self._model_instance.graph_data
+
+                #except Exception as e:
+                #    raise e  # RuntimeError("Failed to update the graph.") from e
+            else:
+                # future implementation
+                # _graph = anemoi.graphs.create() <-- skeleton
+                # self._model_instance.graph_data = _graph <- update graph obj within inst
+                # return _graph <- return graph
+                raise NotImplementedError
 
     @cached_property
     def set_base_seed(self) -> None:

--- a/bris/checkpoint.py
+++ b/bris/checkpoint.py
@@ -163,10 +163,8 @@ class Checkpoint:
                 "Graph has already been updated. Mutliple updates is not allowed"
             )
         else:
-            if path:
-                assert os.path.exists(
-                    path
-                ), f"Cannot locate graph file. Got path: {path}"
+            if path and os.path.exists(path):
+                
                 external_graph = torch.load(path, map_location="cpu",weights_only=False)
                 LOGGER.info("Loaded external graph from path")
                 

--- a/bris/checkpoint.py
+++ b/bris/checkpoint.py
@@ -170,26 +170,28 @@ class Checkpoint:
                 external_graph = torch.load(path, map_location="cpu",weights_only=False)
                 LOGGER.info("Loaded external graph from path")
                 
-                try:
-                    self._model_instance.graph_data = external_graph
-                    self._model_instance.config = self.config #conf 
+                self._model_instance.graph_data = external_graph
+                self._model_instance.config = self.config #conf 
 
-                    LOGGER.info("Rebuilding layers to support new graph")
+                LOGGER.info("Rebuilding layers to support new graph")
+                
+                try: 
                     self._model_instance._build_model()
                     self.UPDATE_GRAPH = True
-
-                    _model_params = self._model_params
-
-                    for layer_name, param in self._model_instance.named_parameters():
-                        param.data = _model_params[layer_name].data
-
-                    LOGGER.info(
-                        "Successfully builded model with external graph and reassigning model weights!"
-                    )
-                    return self._model_instance.graph_data
-
+                
                 except Exception as e:
-                    raise RuntimeError("Failed to update the graph.") from e
+                    raise RuntimeError("Failed to rebuild model with new graph.") from e
+
+                _model_params = self._model_params
+                
+                for layer_name, param in self._model_instance.named_parameters():
+                    param.data = _model_params[layer_name].data
+
+                LOGGER.info(
+                    "Successfully builded model with external graph and reassigning model weights!"
+                )
+                return self._model_instance.graph_data
+                
             else:
                 # future implementation
                 # _graph = anemoi.graphs.create() <-- skeleton


### PR DESCRIPTION
Added functionality to change the internal graph in the model. This is done by providing a key called "graph" inside the config where the value of "graph" points to a graph file.

`graph: /foo/bar/baz/GRAPH.pt`

This triggers: changing the internal graph ->  building a new model with respect to the new graph -> reassigns the model weights to the new model. 