### PR TITLE
Improve dataloading

### DIFF
--- a/bris/__main__.py
+++ b/bris/__main__.py
@@ -91,10 +91,10 @@ def main():
     # Get outputs and required_variables of each decoder
     leadtimes = np.arange(config.leadtimes) * timestep_seconds
     decoder_outputs = bris.routes.get(
-        config["routing"], leadtimes, num_members, datamodule, config.workdir
+        config["routing"], leadtimes, num_members, datamodule, checkpoint, config.workdir
     )
     required_variables = bris.routes.get_required_variables(
-        config["routing"], datamodule
+        config["routing"], checkpoint
     )
     writer = CustomWriter(decoder_outputs, write_interval="batch")
 

--- a/bris/__main__.py
+++ b/bris/__main__.py
@@ -91,7 +91,12 @@ def main():
     # Get outputs and required_variables of each decoder
     leadtimes = np.arange(config.leadtimes) * timestep_seconds
     decoder_outputs = bris.routes.get(
-        config["routing"], leadtimes, num_members, datamodule, checkpoint, config.workdir
+        config["routing"],
+        leadtimes,
+        num_members,
+        datamodule,
+        checkpoint,
+        config.workdir,
     )
     required_variables = bris.routes.get_required_variables(
         config["routing"], checkpoint

--- a/bris/__main__.py
+++ b/bris/__main__.py
@@ -110,7 +110,7 @@ def main():
         config.model,
         checkpoint=checkpoint,
         hardware_config=config.hardware,
-        data_reader=datamodule.data_reader,
+        datamodule=datamodule,
         forecast_length=config.leadtimes,
         required_variables=required_variables,
         release_cache=config.release_cache,

--- a/bris/data/datamodule.py
+++ b/bris/data/datamodule.py
@@ -43,7 +43,7 @@ class DataModule(pl.LightningDataModule):
 
         self.config = config
         self.graph = checkpoint_object.graph
-        self.ckptObj = checkpoint_object
+        self.checkpoint_object = checkpoint_object
         self.timestep = config.timestep
         self.frequency = config.frequency
 
@@ -91,7 +91,7 @@ class DataModule(pl.LightningDataModule):
             config=self.config.dataloader.datamodule,
             data_reader=data_reader,
             rollout=0,
-            multistep=self.ckptObj.multistep,
+            multistep=self.checkpoint_object.multistep,
             timeincrement=self.timeincrement,
             grid_indices=self.grid_indices,
             label="predict",
@@ -160,7 +160,7 @@ class DataModule(pl.LightningDataModule):
     def grid_indices(self) -> type[BaseGridIndices]:
         # TODO: This currently only supports fullgrid for multi-encoder/decoder
         reader_group_size = 1  # Generalize this later
-        graph_cfg = self.ckptObj.config.graph
+        graph_cfg = self.checkpoint_object.config.graph
 
         # Multi_encoder/decoder
         if "input_nodes" in graph_cfg:

--- a/bris/data/datamodule.py
+++ b/bris/data/datamodule.py
@@ -152,7 +152,10 @@ class DataModule(pl.LightningDataModule):
         Returns a tuple of dictionaries, where each dict is:
             variable_name -> index
         """
-        return self.ckptObj.name_to_index
+        if isinstance(self.data_reader.name_to_index, dict):
+            return (self.data_reader.name_to_index,)
+        return self.data_reader.name_to_index
+
 
     @cached_property
     def grid_indices(self) -> type[BaseGridIndices]:

--- a/bris/data/datamodule.py
+++ b/bris/data/datamodule.py
@@ -156,7 +156,6 @@ class DataModule(pl.LightningDataModule):
             return (self.data_reader.name_to_index,)
         return self.data_reader.name_to_index
 
-
     @cached_property
     def grid_indices(self) -> type[BaseGridIndices]:
         # TODO: This currently only supports fullgrid for multi-encoder/decoder

--- a/bris/forcings.py
+++ b/bris/forcings.py
@@ -102,18 +102,20 @@ def cos_solar_zenith_angle(date, lat, lon):
     )
     return result.flatten()
 
+
 def anemoi_dynamic_forcings():
     """
     Returns list of dynamic forcings calculated by anemoi datasets.
     If this list is updated the forcing should also be implemented in get_dynamic_forcings
     """
     return [
-        "cos_julian_day", 
-        "sin_julian_day", 
-        "cos_local_time", 
-        "sin_local_time", 
-        "insolation"
-        ]
+        "cos_julian_day",
+        "sin_julian_day",
+        "cos_local_time",
+        "sin_local_time",
+        "insolation",
+    ]
+
 
 def get_dynamic_forcings(time, lats, lons, selection):
     forcings = {}

--- a/bris/forcings.py
+++ b/bris/forcings.py
@@ -102,6 +102,18 @@ def cos_solar_zenith_angle(date, lat, lon):
     )
     return result.flatten()
 
+def anemoi_dynamic_forcings():
+    """
+    Returns list of dynamic forcings calculated by anemoi datasets.
+    If this list is updated the forcing should also be implemented in get_dynamic_forcings
+    """
+    return [
+        "cos_julian_day", 
+        "sin_julian_day", 
+        "cos_local_time", 
+        "sin_local_time", 
+        "insolation"
+        ]
 
 def get_dynamic_forcings(time, lats, lons, selection):
     forcings = {}

--- a/bris/model.py
+++ b/bris/model.py
@@ -8,13 +8,13 @@ from typing import Any
 import numpy as np
 import pytorch_lightning as pl
 import torch
-from torch.distributed.distributed_c10d import ProcessGroup
 from anemoi.models.data_indices.index import DataIndex, ModelIndex
+from torch.distributed.distributed_c10d import ProcessGroup
 
 from .checkpoint import Checkpoint
-from .forcings import get_dynamic_forcings, anemoi_dynamic_forcings
-from .utils import check_anemoi_training, timedelta64_from_timestep
 from .data.datamodule import DataModule
+from .forcings import anemoi_dynamic_forcings, get_dynamic_forcings
+from .utils import check_anemoi_training, timedelta64_from_timestep
 
 LOGGER = logging.getLogger(__name__)
 

--- a/bris/model.py
+++ b/bris/model.py
@@ -90,7 +90,10 @@ class BasePredictor(pl.LightningModule):
         self.reader_group_size = reader_group_size
 
     @abstractmethod
-    def get_static_forcings(self, datareader: Iterable, ):
+    def get_static_forcings(
+        self,
+        datareader: Iterable,
+    ):
         pass
 
     @abstractmethod
@@ -99,7 +102,10 @@ class BasePredictor(pl.LightningModule):
 
     @abstractmethod
     def advance_input_predict(
-        self, x: Union[torch.Tensor, List[torch.Tensor]], y_pred: Union[torch.Tensor, List[torch.Tensor]], time: np.datetime64
+        self,
+        x: Union[torch.Tensor, List[torch.Tensor]],
+        y_pred: Union[torch.Tensor, List[torch.Tensor]],
+        time: np.datetime64,
     ) -> torch.Tensor:
         pass
 
@@ -148,9 +154,7 @@ class BrisPredictor(BasePredictor):
             self.internal_model,
             0,
         )
-        self.set_static_forcings(
-            datamodule.data_reader, self.metadata.config.data
-        )
+        self.set_static_forcings(datamodule.data_reader, self.metadata.config.data)
 
         self.model.eval()
         self.release_cache = release_cache
@@ -422,7 +426,9 @@ class MultiEncDecPredictor(BasePredictor):
     def forward(self, x: torch.Tensor) -> List[torch.Tensor]:
         return self.model(x, self.model_comm_group)
 
-    def advance_input_predict(self, x: List[torch.Tensor], y_pred: List[torch.Tensor], time: np.datetime64):
+    def advance_input_predict(
+        self, x: List[torch.Tensor], y_pred: List[torch.Tensor], time: np.datetime64
+    ):
         for i in range(len(x)):
             x[i] = x[i].roll(-1, dims=1)
             # Get prognostic variables:

--- a/bris/model.py
+++ b/bris/model.py
@@ -107,10 +107,6 @@ class BasePredictor(pl.LightningModule):
     def predict_step(self, batch: torch.Tensor, batch_idx: int) -> torch.Tensor:
         pass
 
-    @abstractmethod
-    def set_variable_indices(self, required_variables: list):
-        pass
-
 
 class BrisPredictor(BasePredictor):
     def __init__(
@@ -119,7 +115,7 @@ class BrisPredictor(BasePredictor):
         checkpoint: Checkpoint,
         datamodule: DataModule,
         forecast_length: int,
-        required_variables: list,
+        required_variables: dict,
         release_cache: bool = False,
         **kwargs,
     ) -> None:
@@ -145,7 +141,7 @@ class BrisPredictor(BasePredictor):
             self.internal_model = self.data_indices.model
             self.internal_data = self.data_indices.data
 
-        self.indices, self.variables = get_variable_indices(required_variables[0], datamodule, self.internal_data, self.internal_model, 0)
+        self.indices, self.variables = get_variable_indices(required_variables[0], datamodule.data_reader.variables, self.internal_data, self.internal_model, 0)
         self.set_static_forcings(datamodule.data_reader, self.metadata.config.data.forcing)
 
         self.model.eval()
@@ -191,19 +187,6 @@ class BrisPredictor(BasePredictor):
             ].float()
 
         del data_normalized
-
-    def set_variable_indices(self, required_variables: list) -> None:
-        required_variables = required_variables[0]  # Assume one decoder
-        variable_indices_input = list()
-        variable_indices_output = list()
-        for name in required_variables:
-            index_input = self.internal_data.input.name_to_index[name]
-            variable_indices_input += [index_input]
-            index_output = self.internal_model.output.name_to_index[name]
-            variable_indices_output += [index_output]
-
-        self.variable_indices_input = variable_indices_input
-        self.variable_indices_output = variable_indices_output
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.model(x, self.model_comm_group)
@@ -307,9 +290,9 @@ class MultiEncDecPredictor(BasePredictor):
         self,
         *args,
         checkpoint: Checkpoint,
-        data_reader: Iterable,
+        datamodule: DataModule,
         forecast_length: int,
-        required_variables: list,
+        required_variables: dict,
         release_cache: bool = False,
         **kwargs,
     ) -> None:
@@ -320,19 +303,32 @@ class MultiEncDecPredictor(BasePredictor):
 
         self.timestep = timedelta64_from_timestep(self.metadata.config.data.timestep)
         self.forecast_length = forecast_length
-        self.latitudes = data_reader.latitudes
-        self.longitudes = data_reader.longitudes
+        self.latitudes = datamodule.data_reader.latitudes
+        self.longitudes = datamodule.data_reader.longitudes
         self.data_indices = self.model.data_indices
-        self.set_variable_indices(required_variables)
 
-        self.set_static_forcings(data_reader, self.metadata["config"]["data"]["zip"])
+        self.indices = ()
+        self.variables = ()
+        for dec_index, required_vars_dec in required_variables.items():
+            _indices, _variables = get_variable_indices(required_vars_dec, datamodule.data_reader.datasets[dec_index].variables, self.data_indices[dec_index].internal_data, self.data_indices[dec_index].internal_model, dec_index)
+            self.indices += (_indices,)
+            self.variables += (_variables,)
+
+        self.set_static_forcings(datamodule.data_reader, self.metadata["config"]["data"]["zip"])
         self.model.eval()
 
     def set_static_forcings(self, data_reader, zip_config):
         data = data_reader[0]
         num_dsets = len(data)
-        data = [torch.from_numpy(x.squeeze(axis=1).swapaxes(0, 1)) for x in data]
-        data_normalized = self.model.pre_processors(data, in_place=False)
+        data_input = []
+        for dec_index in range(num_dsets):
+            _batch = torch.from_numpy(data[dec_index].squeeze(axis=1).swapaxes(0,1))
+            _data_input = torch.zeros(_batch.shape[:-1] + (len(self.variables[dec_index]["all"]),), dtype=_batch.dtype, device=_batch.device)
+            _data_input[..., self.indices[dec_index]["prognostic_input"]] = _batch[..., self.indices[dec_index]["prognostic_dataset"]]
+            _data_input[..., self.indices[dec_index]["static_forcings_input"]] = _batch[..., self.indices[dec_index]["static_forcings_dataset"]]
+            data_input += [_data_input]
+
+        data_normalized = self.model.pre_processors(data_input, in_place=True)
 
         self.static_forcings = [{} for _ in range(num_dsets)]
         for dset in range(num_dsets):
@@ -359,48 +355,25 @@ class MultiEncDecPredictor(BasePredictor):
 
             if "lsm" in selection:
                 self.static_forcings[dset]["lsm"] = data_normalized[dset][
-                    ..., data_reader.name_to_index[dset]["lsm"]
+                    ..., self.data_indices[dset].internal_data.input.name_to_index["lsm"]
                 ].float()
 
             if "z" in selection:
                 self.static_forcings[dset]["z"] = data_normalized[dset][
-                    ..., data_reader.name_to_index[dset]["z"]
+                    ..., self.data_indices[dset].internal_data.input.name_to_index["z"]
                 ].float()
-
-    def set_variable_indices(self, required_variables: list) -> None:
-        variable_indices_input = [() for _ in required_variables]
-        variable_indices_output = [() for _ in required_variables]
-
-        for dec_index, required_vars_dec in required_variables.items():
-            _variable_indices_input = list()
-            _variable_indices_output = list()
-            for name in required_vars_dec:
-                index_input = self.data_indices[
-                    dec_index
-                ].internal_data.input.name_to_index[name]
-                _variable_indices_input += [index_input]
-                index_output = self.data_indices[
-                    dec_index
-                ].internal_model.output.name_to_index[name]
-                _variable_indices_output += [index_output]
-            variable_indices_input[dec_index] = _variable_indices_input
-            variable_indices_output[dec_index] = _variable_indices_output
-
-        self.variable_indices_input = variable_indices_input
-        self.variable_indices_output = variable_indices_output
 
     def forward(self, x: torch.Tensor) -> list[torch.Tensor]:
         return self.model(x, self.model_comm_group)
 
     def advance_input_predict(self, x, y_pred, time):
-        data_indices = self.model.data_indices
 
         for i in range(len(x)):
             x[i] = x[i].roll(-1, dims=1)
             # Get prognostic variables:
-            x[i][:, -1, :, :, data_indices[i].internal_model.input.prognostic] = y_pred[
+            x[i][:, -1, :, :, self.data_indices[i].internal_model.input.prognostic] = y_pred[
                 i
-            ][..., data_indices[i].internal_model.output.prognostic]
+            ][..., self.data_indices[i].internal_model.output.prognostic]
 
             forcings = get_dynamic_forcings(
                 time,
@@ -417,7 +390,7 @@ class MultiEncDecPredictor(BasePredictor):
                         -1,
                         :,
                         :,
-                        data_indices[i].internal_model.input.name_to_index[forcing],
+                        self.data_indices[i].internal_model.input.name_to_index[forcing],
                     ] = torch.from_numpy(value)
                 else:
                     x[i][
@@ -425,7 +398,7 @@ class MultiEncDecPredictor(BasePredictor):
                         -1,
                         :,
                         :,
-                        data_indices[i].internal_model.input.name_to_index[forcing],
+                        self.data_indices[i].internal_model.input.name_to_index[forcing],
                     ] = value
 
         return x
@@ -433,7 +406,6 @@ class MultiEncDecPredictor(BasePredictor):
     @torch.inference_mode
     def predict_step(self, batch: list, batch_idx: int) -> list:
         num_dsets = len(batch)
-        data_indices = self.model.data_indices
         multistep = self.metadata["config"]["training"]["multistep_input"]
 
         batch, time_stamp = batch
@@ -445,24 +417,36 @@ class MultiEncDecPredictor(BasePredictor):
                     batch[i].shape[0],
                     self.forecast_length,
                     batch[i].shape[-2],
-                    len(self.variable_indices_input[i]),
+                    len(self.indices[i]["variables_input"]),
                 ),
                 dtype=batch[i].dtype,
                 device="cpu",
             )
             for i in range(num_dsets)
         ]
-        # Insert analysis for t=0
-        for i in range(num_dsets):
-            y_analysis = batch[i][:, multistep - 1, 0, ...]
-            y_analysis[..., data_indices[i].internal_data.output.diagnostic] = 0.0
-            y_preds[i][:, 0, ...] = y_analysis[..., self.variable_indices_input[i]]
+        data_input = []
+        for dec_index in range(num_dsets):
+            _data_input = torch.zeros(batch[dec_index].shape[:-1] + (len(self.variables[dec_index]["all"]),), dtype=batch[dec_index].dtype, device=batch[dec_index].device)
+            _data_input[..., self.indices[dec_index]["prognostic_input"]] = batch[dec_index][..., self.indices[dec_index]["prognostic_dataset"]]
+            _data_input[..., self.indices[dec_index]["static_forcings_input"]] = batch[dec_index][..., self.indices[dec_index]["static_forcings_dataset"]]
+            
+            # Calculate dynamic forcings and add these to data_input
+            for time_index in range(multistep):
+                toi = time - (multistep-1-time_index)*self.timestep
+                forcings = get_dynamic_forcings(toi, self.latitudes[dec_index], self.longitudes[dec_index], self.variables[dec_index]["dynamic_forcings"])
 
-        batch = self.model.pre_processors(batch, in_place=True)
-        x = [
-            batch[i][..., data_indices[i].internal_data.input.full]
-            for i in range(num_dsets)
-        ]
+                for forcing, value in forcings.items():
+                    if isinstance(value, np.ndarray): 
+                        _data_input[:, time_index, :, :, self.data_indices[dec_index].internal_data.input.name_to_index[forcing]] = torch.from_numpy(value).to(dtype=_data_input.dtype)
+                    else:
+                        _data_input[:, time_index, :, :, self.data_indices[dec_index].internal_data.input.name_to_index[forcing]] = value
+            data_input += [_data_input]
+
+            y_preds[dec_index][:,0,:,:] = data_input[dec_index][:,multistep-1,...,self.indices[dec_index]["variables_input"]].cpu()
+
+        data_input = self.model.pre_processors(data_input, in_place=True)
+        x = [data_input[i][..., self.data_indices[i].internal_data.input.full] for i in range(num_dsets)]
+
 
         with torch.amp.autocast(device_type="cuda", dtype=torch.bfloat16):
             for fcast_step in range(self.forecast_length - 1):
@@ -472,7 +456,7 @@ class MultiEncDecPredictor(BasePredictor):
                 y_pp = self.model.post_processors(y_pred, in_place=False)
                 for i in range(num_dsets):
                     y_preds[i][:, fcast_step + 1, ...] = y_pp[i][
-                        :, 0, ..., self.variable_indices_output[i]
+                        :, 0, ..., self.indices[i]["variables_output"]
                     ].cpu()
                 times.append(time)
 
@@ -485,7 +469,7 @@ class MultiEncDecPredictor(BasePredictor):
     
 
 
-def get_variable_indices(required_variables: list, datamodule: DataModule, internal_data: DataIndex, internal_model: ModelIndex, decoder_index: int) -> dict:
+def get_variable_indices(required_variables: list, datamodule_variables: list, internal_data: DataIndex, internal_model: ModelIndex, decoder_index: int) -> dict:
     # Set up indices for the variables we want to write to file
     variable_indices_input = list()
     variable_indices_output = list()
@@ -494,7 +478,6 @@ def get_variable_indices(required_variables: list, datamodule: DataModule, inter
         variable_indices_output.append(internal_model.output.name_to_index[name])
     
     # Set up indices that can map from the variable order in the input data to the input variable order expected by the model
-    # self.full_ordered_variable_list = self.metadata.dataset.variables
     full_ordered_variable_list = [var for var, _ in sorted(internal_data.input.name_to_index.items(), key=lambda item: item[1])]
     
     required_prognostic_variables = [name for name, index in internal_model.input.name_to_index.items() if index in internal_model.input.prognostic]
@@ -502,16 +485,16 @@ def get_variable_indices(required_variables: list, datamodule: DataModule, inter
     required_dynamic_forcings = [forcing for forcing in anemoi_dynamic_forcings() if forcing in required_forcings]
     required_static_forcings = [forcing for forcing in required_forcings if forcing not in anemoi_dynamic_forcings()]
 
-    missing_vars = [var for var in required_prognostic_variables + required_static_forcings if var not in datamodule.data_reader.variables]
+    missing_vars = [var for var in required_prognostic_variables + required_static_forcings if var not in datamodule_variables]
     if len(missing_vars) > 0:
         raise ValueError(f"Missing the following required variables in dataset {decoder_index}: {missing_vars}")
     
-    indices_prognostic_dataset = torch.tensor([index for index, var in enumerate(datamodule.data_reader.variables) if var in required_prognostic_variables], dtype=torch.int64)
-    indices_static_forcings_dataset = torch.tensor([index for index, var in enumerate(datamodule.data_reader.variables) if var in required_static_forcings], dtype=torch.int64)
+    indices_prognostic_dataset = torch.tensor([index for index, var in enumerate(datamodule_variables) if var in required_prognostic_variables], dtype=torch.int64)
+    indices_static_forcings_dataset = torch.tensor([index for index, var in enumerate(datamodule_variables) if var in required_static_forcings], dtype=torch.int64)
     
-    indices_prognostic_input = torch.tensor([full_ordered_variable_list.index(var) for var in datamodule.data_reader.variables if var in required_prognostic_variables], dtype=torch.int64)
-    indices_static_forcings_input = torch.tensor([full_ordered_variable_list.index(var) for var in datamodule.data_reader.variables if var in required_static_forcings], dtype=torch.int64)
-    indices_dynamic_forcings_input = torch.tensor([full_ordered_variable_list.index(var) for var in datamodule.data_reader.variables if var in required_dynamic_forcings], dtype=torch.int64)
+    indices_prognostic_input = torch.tensor([full_ordered_variable_list.index(var) for var in datamodule_variables if var in required_prognostic_variables], dtype=torch.int64)
+    indices_static_forcings_input = torch.tensor([full_ordered_variable_list.index(var) for var in datamodule_variables if var in required_static_forcings], dtype=torch.int64)
+    indices_dynamic_forcings_input = torch.tensor([full_ordered_variable_list.index(var) for var in datamodule_variables if var in required_dynamic_forcings], dtype=torch.int64)
 
     indices = {
             "variables_input": variable_indices_input,

--- a/bris/routes.py
+++ b/bris/routes.py
@@ -4,9 +4,9 @@ import numpy as np
 
 import bris.outputs
 from bris import utils
+from bris.checkpoint import Checkpoint
 from bris.data.datamodule import DataModule
 from bris.predict_metadata import PredictMetadata
-from bris.checkpoint import Checkpoint
 
 
 def get(

--- a/bris/routes.py
+++ b/bris/routes.py
@@ -6,6 +6,7 @@ import bris.outputs
 from bris import utils
 from bris.data.datamodule import DataModule
 from bris.predict_metadata import PredictMetadata
+from bris.checkpoint import Checkpoint
 
 
 def get(
@@ -13,6 +14,7 @@ def get(
     leadtimes: list,
     num_members: int,
     data_module: DataModule,
+    ckptObj: Checkpoint,
     workdir: str,
 ):
     """Returns outputs for each decoder and domain
@@ -35,7 +37,7 @@ def get(
 
     """
     ret = list()
-    required_variables = get_required_variables(routing_config, data_module)
+    required_variables = get_required_variables(routing_config, ckptObj)
 
     count = 0
     for config in routing_config:
@@ -93,27 +95,8 @@ def get(
     return ret
 
 
-def get_variable_indices(
-    routing_config: dict, data_module: DataModule
-) -> dict[int, list[int]]:
-    """Returns a list of variable indices for each decoder
-
-    This is used by Model
-    """
-    required_variables = get_required_variables(routing_config, data_module)
-
-    variable_indices: dict[int, list[int]] = dict()
-    for decoder_index, _r in required_variables.items():
-        variable_indices[decoder_index] = list()
-        for name in required_variables[decoder_index]:
-            index = data_module.name_to_index[decoder_index][name]
-            variable_indices[decoder_index] += [index]
-
-    return variable_indices
-
-
 def get_required_variables(
-    routing_config: dict, data_module: DataModule
+    routing_config: dict, ckptObj: Checkpoint
 ) -> dict[int, list[str]]:
     """Returns a list of required variables for each decoder"""
     required_variables: dict[int, list[str]] = defaultdict(list)
@@ -126,15 +109,8 @@ def get_required_variables(
 
     for decoder_index, v in required_variables.items():
         if None in v:
-            name_to_index = data_module.name_to_index[decoder_index]
-
-            # Pre-initialize list
-            required_variables[decoder_index] = list(name_to_index.keys())
-
-            for name, index in name_to_index.items():
-                assert index < len(name_to_index)
-
-                required_variables[decoder_index][index] = name
+            name_to_index = ckptObj.model_output_name_to_index[decoder_index]
+            required_variables[decoder_index] = sorted(list(set(name_to_index.keys())))
         else:
             required_variables[decoder_index] = sorted(list(set(v)))
 

--- a/bris/routes.py
+++ b/bris/routes.py
@@ -14,7 +14,7 @@ def get(
     leadtimes: list,
     num_members: int,
     data_module: DataModule,
-    ckptObj: Checkpoint,
+    checkpoint_object: Checkpoint,
     workdir: str,
 ):
     """Returns outputs for each decoder and domain
@@ -37,7 +37,7 @@ def get(
 
     """
     ret = list()
-    required_variables = get_required_variables(routing_config, ckptObj)
+    required_variables = get_required_variables(routing_config, checkpoint_object)
 
     count = 0
     for config in routing_config:
@@ -96,7 +96,7 @@ def get(
 
 
 def get_required_variables(
-    routing_config: dict, ckptObj: Checkpoint
+    routing_config: dict, checkpoint_object: Checkpoint
 ) -> dict[int, list[str]]:
     """Returns a list of required variables for each decoder"""
     required_variables: dict[int, list[str]] = defaultdict(list)
@@ -109,7 +109,7 @@ def get_required_variables(
 
     for decoder_index, v in required_variables.items():
         if None in v:
-            name_to_index = ckptObj.model_output_name_to_index[decoder_index]
+            name_to_index = checkpoint_object.model_output_name_to_index[decoder_index]
             required_variables[decoder_index] = sorted(list(set(name_to_index.keys())))
         else:
             required_variables[decoder_index] = sorted(list(set(v)))

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -32,9 +32,10 @@ class FakeDataModule:
 
 
 class FakeCheckpointObject:
-     @property
-     def model_output_name_to_index(self):
-         return [{"2t": 0, "10u": 1, "10v": 2}, {"100v": 0, "100u": 1}]
+    @property
+    def model_output_name_to_index(self):
+        return [{"2t": 0, "10u": 1, "10v": 2}, {"100v": 0, "100u": 1}]
+
 
 def test_get():
     config = list()
@@ -91,8 +92,9 @@ def test_get():
     for key in required_variables:
         assert set(required_variables[key]) == set(correct_variables[key])
 
-
-    _ = bris.routes.get(config, len(leadtimes), num_members, data_module, ckptObj, workdir)
+    _ = bris.routes.get(
+        config, len(leadtimes), num_members, data_module, ckptObj, workdir
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -31,6 +31,11 @@ class FakeDataModule:
         return [{"2t": 0, "10u": 1, "10v": 2}, {"100v": 0, "100u": 1}]
 
 
+class FakeCheckpointObject:
+     @property
+     def model_output_name_to_index(self):
+         return [{"2t": 0, "10u": 1, "10v": 2}, {"100v": 0, "100u": 1}]
+
 def test_get():
     config = list()
     filename = os.path.dirname(os.path.abspath(__file__)) + "/files/verif_input.nc"
@@ -76,17 +81,18 @@ def test_get():
         },
     ]
     data_module = FakeDataModule()
+    ckptObj = FakeCheckpointObject()
     workdir = "testdir"
     leadtimes = range(66)
     num_members = 2
 
-    required_variables = bris.routes.get_required_variables(config, data_module)
-    assert required_variables == {0: ["2t", "10u", "10v"], 1: ["100u"]}
+    required_variables = bris.routes.get_required_variables(config, ckptObj)
+    correct_variables = {0: ["2t", "10u", "10v"], 1: ["100u"]}
+    for key in required_variables:
+        assert set(required_variables[key]) == set(correct_variables[key])
 
-    variable_indices = bris.routes.get_variable_indices(config, data_module)
-    assert variable_indices == {0: [0, 1, 2], 1: [1]}
 
-    _ = bris.routes.get(config, len(leadtimes), num_members, data_module, workdir)
+    _ = bris.routes.get(config, len(leadtimes), num_members, data_module, ckptObj, workdir)
 
 
 if __name__ == "__main__":

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -82,18 +82,18 @@ def test_get():
         },
     ]
     data_module = FakeDataModule()
-    ckptObj = FakeCheckpointObject()
+    checkpoint_object = FakeCheckpointObject()
     workdir = "testdir"
     leadtimes = range(66)
     num_members = 2
 
-    required_variables = bris.routes.get_required_variables(config, ckptObj)
+    required_variables = bris.routes.get_required_variables(config, checkpoint_object)
     correct_variables = {0: ["2t", "10u", "10v"], 1: ["100u"]}
     for key in required_variables:
         assert set(required_variables[key]) == set(correct_variables[key])
 
     _ = bris.routes.get(
-        config, len(leadtimes), num_members, data_module, ckptObj, workdir
+        config, len(leadtimes), num_members, data_module, checkpoint_object, workdir
     )
 
 


### PR DESCRIPTION
Removes the need to use the exact same dataset / variable order that was used during training. 
The inference dataset now only has to contain prognostic variables and static forcings (in any order). If the inference dataset(s) do not contain the required variables a list of missing variables will be printed. 
Tested on single- and multi-encoder/decoder models.
