### PR TITLE
Allow use of multiple checkpoints 

### DIFF
--- a/bris/__main__.py
+++ b/bris/__main__.py
@@ -28,8 +28,6 @@ def main():
     config = create_config(parser)
 
     models = list(config.models.keys())
-    # TODO: ALLOW FOR THE INTERPOLATOR AND FORECASTER TO HAVE DIFFERENT FORECASTS
-    # Prioritize output from forecaster if both can produce it.
 
     checkpoints = {
         model: Checkpoint(
@@ -37,7 +35,6 @@ def main():
         )
         for model in models
     }
-    # TODO: Force that the first one is always called forecaster here?
 
     set_encoder_decoder_num_chunks(getattr(config, "inference_num_chunks", 1))
     set_base_seed()  # TODO: See if we can remove this

--- a/bris/__main__.py
+++ b/bris/__main__.py
@@ -14,7 +14,7 @@ from bris.data.datamodule import DataModule
 
 from .checkpoint import Checkpoint
 from .inference import Inference
-from .utils import create_config, set_encoder_decoder_num_chunks, set_base_seed
+from .utils import create_config, set_base_seed, set_encoder_decoder_num_chunks
 from .writer import CustomWriter
 
 LOGGER = logging.getLogger(__name__)
@@ -28,14 +28,19 @@ def main():
     config = create_config(parser)
 
     models = list(config.models.keys())
-    #TODO: ALLOW FOR THE INTERPOLATOR AND FORECASTER TO HAVE DIFFERENT FORECASTS
+    # TODO: ALLOW FOR THE INTERPOLATOR AND FORECASTER TO HAVE DIFFERENT FORECASTS
     # Prioritize forecaster output
 
-    checkpoints = {model: Checkpoint(config.models[model].checkpoint_path, config.models[model].graph) for model in models}
-    #TODO: Force that the first one is always called forecaster here?
+    checkpoints = {
+        model: Checkpoint(
+            config.models[model].checkpoint_path, config.models[model].graph
+        )
+        for model in models
+    }
+    # TODO: Force that the first one is always called forecaster here?
 
     set_encoder_decoder_num_chunks(getattr(config, "inference_num_chunks", 1))
-    set_base_seed() #TODO: See if we can remove this
+    set_base_seed()  # TODO: See if we can remove this
 
     # Get timestep from checkpoint. Also store a version in seconds for local use.
     config.timestep = None

--- a/bris/__main__.py
+++ b/bris/__main__.py
@@ -29,7 +29,7 @@ def main():
 
     models = list(config.models.keys())
     # TODO: ALLOW FOR THE INTERPOLATOR AND FORECASTER TO HAVE DIFFERENT FORECASTS
-    # Prioritize forecaster output
+    # Prioritize output from forecaster if both can produce it.
 
     checkpoints = {
         model: Checkpoint(

--- a/bris/checkpoint.py
+++ b/bris/checkpoint.py
@@ -201,7 +201,6 @@ class Checkpoint:
 
         LOGGER.info("Rebuilding layers to support the new graph.")
         self._model_instance._build_model()
-        self.is_graph_replaced = True
 
         # Validate parameter count consistency.
         old_param_count = len(_model_params)
@@ -216,7 +215,7 @@ class Checkpoint:
             param.data = _model_params[layer_name].data
 
         LOGGER.info(
-            "Successfully builded model with external graph and reassigning model weights!"
+            "Successfully built model with external graph and reassigning model weights!"
         )
         return self._model_instance.graph_data
 

--- a/bris/checkpoint.py
+++ b/bris/checkpoint.py
@@ -188,10 +188,7 @@ class Checkpoint:
         # stretched grid, the model instance will complain
         # (not 100% sure but i think i have experienced this)
 
-
-        external_graph = torch.load(
-            path, map_location="cpu", weights_only=False
-        )
+        external_graph = torch.load(path, map_location="cpu", weights_only=False)
         LOGGER.info("Loaded external graph from path")
 
         self._model_instance.graph_data = external_graph

--- a/bris/inference.py
+++ b/bris/inference.py
@@ -21,13 +21,11 @@ class Inference:
         model: pl.LightningModule,
         callbacks: Any,
         datamodule: DataModule,
-        checkpoint: Checkpoint,
         precision: Optional[str] = None,
         device: Optional[str] = None,
     ) -> None:
         self.config = config
         self.model = model
-        self.checkpoint = checkpoint
         self.callbacks = callbacks
         self.datamodule = datamodule
         self.precision = precision

--- a/bris/model.py
+++ b/bris/model.py
@@ -21,7 +21,11 @@ LOGGER = logging.getLogger(__name__)
 
 class BasePredictor(pl.LightningModule):
     def __init__(
-        self, *args: Any, checkpoint: dict[str, Checkpoint], hardware_config: dict, **kwargs: Any
+        self,
+        *args: Any,
+        checkpoints: dict[str, Checkpoint],
+        hardware_config: dict,
+        **kwargs: Any,
     ):
         """
         Base predictor class, overwrite all the class methods
@@ -35,7 +39,7 @@ class BasePredictor(pl.LightningModule):
         self.model_comm_group_rank = 0
         self.model_comm_num_groups = 1
 
-        if check_anemoi_training(checkpoint.metadata):
+        if check_anemoi_training(checkpoints["forecaster"].metadata):
             self.legacy = False
         else:
             self.legacy = True
@@ -125,7 +129,7 @@ class BrisPredictor(BasePredictor):
         release_cache: bool = False,
         **kwargs,
     ) -> None:
-        super().__init__(*args, checkpoint=checkpoint, **kwargs)
+        super().__init__(*args, checkpoints=checkpoints, **kwargs)
 
         checkpoint = checkpoints["forecaster"]
         self.model = checkpoint.model
@@ -333,14 +337,14 @@ class MultiEncDecPredictor(BasePredictor):
     def __init__(
         self,
         *args,
-        checkpoints: dict[str, Checkpoints],
+        checkpoints: dict[str, Checkpoint],
         datamodule: DataModule,
         forecast_length: int,
         required_variables: dict,
         release_cache: bool = False,
         **kwargs,
     ) -> None:
-        super().__init__(*args, checkpoint=checkpoint, **kwargs)
+        super().__init__(*args, checkpoints=checkpoints, **kwargs)
 
         checkpoint = checkpoints["forecaster"]
         self.model = checkpoint.model
@@ -566,7 +570,9 @@ class MultiEncDecPredictor(BasePredictor):
             "group_rank": self.model_comm_group_rank,
             "ensemble_member": 0,
         }
-'''
+
+
+"""
 class Interpolator(BasePredictor):
     def __init__(
         self,
@@ -632,10 +638,8 @@ class Interpolator(BasePredictor):
             # Add everything to y_preds
 
             # Next timestep'
-'''    
+"""
 
-
-    
 
 def get_variable_indices(
     required_variables: list,

--- a/bris/routes.py
+++ b/bris/routes.py
@@ -14,7 +14,7 @@ def get(
     leadtimes: list,
     num_members: int,
     data_module: DataModule,
-    checkpoint_object: Checkpoint,
+    checkpoints: dict[str,Checkpoint],
     workdir: str,
 ):
     """Returns outputs for each decoder and domain
@@ -36,8 +36,15 @@ def get(
             decoder_index -> variable_indices
 
     """
+    
     ret = list()
-    required_variables = get_required_variables(routing_config, checkpoint_object)
+    required_variables_per_model = {model: get_required_variables(routing_config, checkpoint) for model, checkpoint in checkpoints.items()}
+    required_variables_full = defaultdict(set)
+    for model, _required_variables in required_variables_per_model.items():
+        for key, variable_list in _required_variables.items():
+            required_variables_full[key].update(variable_list)
+    
+    required_variables = {key: list(values) for key, values in required_variables_full.items()}
 
     count = 0
     for config in routing_config:

--- a/bris/routes.py
+++ b/bris/routes.py
@@ -14,7 +14,7 @@ def get(
     leadtimes: list,
     num_members: int,
     data_module: DataModule,
-    checkpoints: dict[str,Checkpoint],
+    checkpoints: dict[str, Checkpoint],
     workdir: str,
 ):
     """Returns outputs for each decoder and domain
@@ -36,15 +36,20 @@ def get(
             decoder_index -> variable_indices
 
     """
-    
+
     ret = list()
-    required_variables_per_model = {model: get_required_variables(routing_config, checkpoint) for model, checkpoint in checkpoints.items()}
+    required_variables_per_model = {
+        model: get_required_variables(routing_config, checkpoint)
+        for model, checkpoint in checkpoints.items()
+    }
     required_variables_full = defaultdict(set)
-    for model, _required_variables in required_variables_per_model.items():
+    for _, _required_variables in required_variables_per_model.items():
         for key, variable_list in _required_variables.items():
             required_variables_full[key].update(variable_list)
-    
-    required_variables = {key: list(values) for key, values in required_variables_full.items()}
+
+    required_variables = {
+        key: list(values) for key, values in required_variables_full.items()
+    }
 
     count = 0
     for config in routing_config:

--- a/bris/utils.py
+++ b/bris/utils.py
@@ -81,9 +81,9 @@ def create_config(parser: ArgumentParser) -> OmegaConf:
     except Exception as e:
         raise e
 
-#    parser.add_argument(
-#        "-c", type=str, dest="checkpoint_path", default=config.checkpoint_path
-#    )
+    #    parser.add_argument(
+    #        "-c", type=str, dest="checkpoint_path", default=config.checkpoint_path
+    #    )
     parser.add_argument(
         "-sd",
         type=str,
@@ -242,6 +242,7 @@ def set_encoder_decoder_num_chunks(chunks: int = 1) -> None:
     )
     os.environ["ANEMOI_INFERENCE_NUM_CHUNKS"] = str(chunks)
     LOGGER.info("Encoder and decoder are chunked to %s", chunks)
+
 
 def set_base_seed() -> None:
     """

--- a/bris/utils.py
+++ b/bris/utils.py
@@ -81,9 +81,9 @@ def create_config(parser: ArgumentParser) -> OmegaConf:
     except Exception as e:
         raise e
 
-    parser.add_argument(
-        "-c", type=str, dest="checkpoint_path", default=config.checkpoint_path
-    )
+#    parser.add_argument(
+#        "-c", type=str, dest="checkpoint_path", default=config.checkpoint_path
+#    )
     parser.add_argument(
         "-sd",
         type=str,
@@ -234,3 +234,22 @@ def get_base_seed(env_var_list=("AIFS_BASE_SEED", "SLURM_JOB_ID")) -> int:
         base_seed = base_seed * 1000  # make it (hopefully) big enough
 
     return base_seed
+
+
+def set_encoder_decoder_num_chunks(chunks: int = 1) -> None:
+    assert isinstance(chunks, int), (
+        f"Expecting chunks to be int, got: {chunks}, {type(chunks)}"
+    )
+    os.environ["ANEMOI_INFERENCE_NUM_CHUNKS"] = str(chunks)
+    LOGGER.info("Encoder and decoder are chunked to %s", chunks)
+
+def set_base_seed() -> None:
+    """
+    TODO: Explain what this function does.
+
+    Fetchs the original base seed used during training.
+    If not
+    """
+    os.environ["ANEMOI_BASE_SEED"] = "1234"
+    os.environ["AIFS_BASE_SEED"] = "1234"
+    LOGGER.info("ANEMOI_BASE_SEED and ANEMOI_BASE_SEED set to 1234")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -83,6 +83,7 @@ def test_get():
     ]
     data_module = FakeDataModule()
     checkpoint_object = FakeCheckpointObject()
+    checkpoints = {"forecaster": checkpoint_object}
     workdir = "testdir"
     leadtimes = range(66)
     num_members = 2
@@ -93,7 +94,7 @@ def test_get():
         assert set(required_variables[key]) == set(correct_variables[key])
 
     _ = bris.routes.get(
-        config, len(leadtimes), num_members, data_module, checkpoint_object, workdir
+        config, len(leadtimes), num_members, data_module, checkpoints, workdir
     )
 
 


### PR DESCRIPTION
For the combined interpolator-forecaster we need to be able to pass a list of checkpoints (with associated input) through the config. In this pr I'm trying to set up a general structure for how we do this, and then change the code to make it compatible with this structure.
I propose the following structure:
```yaml
model:
  forecaster:
    checkpoint_path: FORECASTER_CHECKPOINT
    graph: null
    static_forcings_dataset: ${dataset}
    leadtimes: 12
  interpolator:
    checkpoint_path: INTERPOLATOR_CHECKPOINT
    graph: null
    static_forcings_dataset: ${dataset}
    leadtimes: ${checkpoints.forecaster.leadtimes}

```

- [ ] Moved graph update to the Checkpoint init
- [ ] Changed routes so required variables will be the union of output from interpolator and forecaster. Then its up to model (TODO) to figure out which output to take from which model.
- [ ] Update test and default configs, update schema.

