### PR TITLE
Add test for distributed run

### DIFF
--- a/config/tox_test_inference_distributed.yaml
+++ b/config/tox_test_inference_distributed.yaml
@@ -1,0 +1,38 @@
+# Minimal config for running inference on CPU. See https://github.com/metno/bris-inference/wiki/Tests
+
+start_date: 2022-01-01T00:00:00
+end_date: 2022-01-02T00:00:00
+
+checkpoints:
+  forecaster:
+    checkpoint_path: ./inference-last.ckpt
+    leadtimes: 2
+
+dataset: ./bris_random_data.zarr
+frequency: 6h
+workdir: /tmp/
+
+dataloader:
+  datamodule:
+    _target_: bris.data.dataset.NativeGridDataset
+    _convert_: all
+
+hardware:
+  num_gpus_per_node: 2
+  num_gpus_per_model: 2
+  num_nodes: 1
+
+release_cache: False
+
+model:
+  _target_: bris.model.BrisPredictor
+  _convert_: all
+
+routing:
+  - decoder_index: 0
+    domain_index: 0
+    domain: 0
+    outputs:
+      - netcdf:
+          filename_pattern: test_pred_%Y%m%dT%HZ.nc
+          variables: [2t, 2d]

--- a/tox.ini
+++ b/tox.ini
@@ -133,6 +133,29 @@ commands_pre =
 commands = bris --config tox_test_inference.yaml
 
 
+[testenv:inference_CI_distributed]
+description = Run inference distributed on multiple CPUs. Only for CI testing.
+; override default:
+deps =
+depends = trainingdata
+change_dir = {envtmpdir}
+allowlist_externals =
+    cp
+    ln
+    find
+commands_pre =
+    # Copy config file to temp directory.
+    cp -vf {toxinidir}/config/tox_test_inference_distributed.yaml {envtmpdir}/
+
+    # Copy checkpont from tests directory.
+    cp ../../../tests/files/checkpoint.ckpt {envtmpdir}/inference-last.ckpt
+
+    # Link data from other tox environment.
+    ln -sf {toxworkdir}/bris_random_data.zarr {envtmpdir}/
+    pip install anemoi-models==0.4.2 # Override anemoi-models to match train environment
+commands = bris --config tox_test_inference_distributed.yaml
+
+
 [testenv:inference_multi_CI]
 description = Run inference with MultiEncDecPredictor. Only for CI testing.
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -153,6 +153,7 @@ commands_pre =
     # Link data from other tox environment.
     ln -sf {toxworkdir}/bris_random_data.zarr {envtmpdir}/
     pip install anemoi-models==0.4.2 # Override anemoi-models to match train environment
+    pip install --pre --upgrade torch --index-url https://download.pytorch.org/whl/nightly/cpu
 commands = bris --config tox_test_inference_distributed.yaml
 
 
@@ -161,7 +162,6 @@ description = Run inference with MultiEncDecPredictor. Only for CI testing.
 deps =
     anemoi-datasets @ git+https://github.com/metno/anemoi-datasets.git@13397aa
     anemoi-models @ git+https://github.com/metno/anemoi-models.git@80c9fbf
-; @ git+https://github.com/metno/anemoi-models.git
 depends = trainingdata
 change_dir = {envtmpdir}
 allowlist_externals =


### PR DESCRIPTION
Test fails. I think it's due to being on CPU(?). If so, the test should be marked clearly. Best solution would be to fix running on CPU.

```
[rank0]:   File "/home/larsfp/src/bris-inference/.tox/inference_CI_distributed/lib/python3.12/site-packages/anemoi/models/distributed/transformer.py", line 141, in forward
[rank0]:     return _headsalltoall(input_, shapes_, group=mgroup_)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/larsfp/src/bris-inference/.tox/inference_CI_distributed/lib/python3.12/site-packages/anemoi/models/distributed/transformer.py", line 53, in _headsalltoall
[rank0]:     dist.all_to_all(output_list, input_list, group=group)
[rank0]:   File "/home/larsfp/src/bris-inference/.tox/inference_CI_distributed/lib/python3.12/site-packages/torch/distributed/c10d_logger.py", line 83, in wrapper
[rank0]:     return func(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/larsfp/src/bris-inference/.tox/inference_CI_distributed/lib/python3.12/site-packages/torch/distributed/distributed_c10d.py", line 4114, in all_to_all
[rank0]:     work = group.alltoall(output_tensor_list, input_tensor_list, opts)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]: RuntimeError: Backend gloo does not support alltoall

```