### PR TITLE
176 Variables definition from expression

### DIFF
--- a/bris/outputs/__init__.py
+++ b/bris/outputs/__init__.py
@@ -101,7 +101,7 @@ class Output:
         # Append extra variables to prediction
         for name in self.extra_variables:
             if name not in self.pm.variables:
-                clean_name = name.replace('[', '').replace(']', '').replace('*', '')
+                clean_name = name.replace("[", "").replace("]", "").replace("*", "")
                 self.pm.variables.append(clean_name)
 
         # only do this once. For multiple members, intermediate calls this several times
@@ -117,7 +117,7 @@ class Output:
                 for v in extr_vars:
                     idx = self.pm.variables.index(v)
                     variables_dict[v] = pred[..., idx]
-                extra_pred += [safe_eval_expr(name, variables_dict)[...,None]]
+                extra_pred += [safe_eval_expr(name, variables_dict)[..., None]]
 
             pred = np.concatenate([pred] + extra_pred, axis=2)
         LOGGER.debug(

--- a/bris/outputs/__init__.py
+++ b/bris/outputs/__init__.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from bris import sources
 from bris.predict_metadata import PredictMetadata
-from bris.utils import datetime_to_unixtime, safe_eval_expr, expr_to_var
+from bris.utils import datetime_to_unixtime, expr_to_var, safe_eval_expr
 
 
 def instantiate(name: str, predict_metadata: PredictMetadata, workdir: str, init_args):

--- a/bris/outputs/__init__.py
+++ b/bris/outputs/__init__.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from bris import sources
 from bris.predict_metadata import PredictMetadata
+from bris.utils import datetime_to_unixtime, safe_eval_expr, expr_to_var
 
 
 def instantiate(name: str, predict_metadata: PredictMetadata, workdir: str, init_args):
@@ -40,32 +41,20 @@ def get_required_variables(name, init_args):
     provided
     """
 
-    if name == "netcdf":
+    if name in ["netcdf", "grib"]:
         if "variables" in init_args:
             variables = init_args["variables"]
             if "extra_variables" in init_args:
                 for var_name in init_args["extra_variables"]:
-                    if var_name == "ws":
-                        variables += ["10u", "10v"]
+                    extr_vars, _, _ = expr_to_var(var_name)
+                    variables.extend(extr_vars)
             variables = sorted(list(set(variables)))
             return variables
         return [None]
 
     if name == "verif":
-        if init_args["variable"] == "ws":
-            return ["10u", "10v"]
-        return [init_args["variable"]]
-
-    if name == "grib":
-        if "variables" in init_args:
-            variables = init_args["variables"]
-            if "extra_variables" in init_args:
-                for name in init_args["extra_variables"]:
-                    if name == "ws":
-                        variables += ["10u", "10v"]
-            variables = sorted(list(set(variables)))
-            return variables
-        return [None]
+        extr_vars, _, _ = expr_to_var(init_args["variable"])
+        return extr_vars
 
     raise ValueError(f"Invalid output: {name}")
 
@@ -104,20 +93,22 @@ class Output:
         # Append extra variables to prediction
         for name in self.extra_variables:
             if name not in self.pm.variables:
-                self.pm.variables.append(name)
+                clean_name = name.replace('[', '').replace(']', '').replace('*', '')
+                self.pm.variables.append(clean_name)
 
         # only do this once. For multiple members, intermediate calls this several times
         if pred.shape[2] != len(self.pm.variables):
             # Append extra variables to prediction
             extra_pred = []
             for name in self.extra_variables:
-                if name == "ws":
-                    Ix = self.pm.variables.index("10u")
-                    Iy = self.pm.variables.index("10v")
-                    curr = np.sqrt(pred[..., [Ix]] ** 2 + pred[..., [Iy]] ** 2)
-                    extra_pred += [curr]
-                else:
-                    raise ValueError(f"No recipe to compute {name}")
+                extr_vars, name, success = expr_to_var(name)
+                assert success, "Variables could not be extracted from expression"
+
+                variables_dict = {}
+                for v in extr_vars:
+                    idx = self.pm.variables.index(v)
+                    variables_dict[v] = pred[..., idx]
+                extra_pred += [safe_eval_expr(name, variables_dict)[...,None]]
 
             pred = np.concatenate([pred] + extra_pred, axis=2)
 

--- a/bris/outputs/__init__.py
+++ b/bris/outputs/__init__.py
@@ -99,7 +99,7 @@ class Output:
         # Append extra variables to prediction
         for name in self.extra_variables:
             if name not in self.pm.variables:
-                clean_name = name.replace('[', '').replace(']', '').replace('*', '')
+                clean_name = name.replace("[", "").replace("]", "").replace("*", "")
                 self.pm.variables.append(clean_name)
 
         # only do this once. For multiple members, intermediate calls this several times
@@ -114,7 +114,7 @@ class Output:
                 for v in extr_vars:
                     idx = self.pm.variables.index(v)
                     variables_dict[v] = pred[..., idx]
-                extra_pred += [safe_eval_expr(name, variables_dict)[...,None]]
+                extra_pred += [safe_eval_expr(name, variables_dict)[..., None]]
 
             pred = np.concatenate([pred] + extra_pred, axis=2)
 

--- a/bris/outputs/__init__.py
+++ b/bris/outputs/__init__.py
@@ -6,8 +6,7 @@ import numpy as np
 
 from bris import sources
 from bris.predict_metadata import PredictMetadata
-from bris.utils import LOGGER
-from bris.utils import datetime_to_unixtime, expr_to_var, safe_eval_expr
+from bris.utils import LOGGER, datetime_to_unixtime, expr_to_var, safe_eval_expr
 
 
 def instantiate(name: str, predict_metadata: PredictMetadata, workdir: str, init_args):

--- a/bris/outputs/__init__.py
+++ b/bris/outputs/__init__.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from bris import sources
 from bris.predict_metadata import PredictMetadata
+from bris.utils import datetime_to_unixtime, safe_eval_expr, expr_to_var
 
 
 def instantiate(name: str, predict_metadata: PredictMetadata, workdir: str, init_args):
@@ -46,32 +47,20 @@ def get_required_variables(name, init_args):
     provided
     """
 
-    if name == "netcdf":
+    if name in ["netcdf", "grib"]:
         if "variables" in init_args:
             variables = init_args["variables"]
             if "extra_variables" in init_args:
                 for var_name in init_args["extra_variables"]:
-                    if var_name == "ws":
-                        variables += ["10u", "10v"]
+                    extr_vars, _, _ = expr_to_var(var_name)
+                    variables.extend(extr_vars)
             variables = sorted(list(set(variables)))
             return variables
         return [None]
 
     if name in ["verif", "powerspectrum_gridded", "powerspectrum_global"]:
-        if init_args["variable"] == "ws":
-            return ["10u", "10v"]
-        return [init_args["variable"]]
-
-    if name == "grib":
-        if "variables" in init_args:
-            variables = init_args["variables"]
-            if "extra_variables" in init_args:
-                for name in init_args["extra_variables"]:
-                    if name == "ws":
-                        variables += ["10u", "10v"]
-            variables = sorted(list(set(variables)))
-            return variables
-        return [None]
+        extr_vars, _, _ = expr_to_var(init_args["variable"])
+        return extr_vars
 
     raise ValueError(f"Invalid output: {name}")
 
@@ -110,20 +99,22 @@ class Output:
         # Append extra variables to prediction
         for name in self.extra_variables:
             if name not in self.pm.variables:
-                self.pm.variables.append(name)
+                clean_name = name.replace('[', '').replace(']', '').replace('*', '')
+                self.pm.variables.append(clean_name)
 
         # only do this once. For multiple members, intermediate calls this several times
         if pred.shape[2] != len(self.pm.variables):
             # Append extra variables to prediction
             extra_pred = []
             for name in self.extra_variables:
-                if name == "ws":
-                    Ix = self.pm.variables.index("10u")
-                    Iy = self.pm.variables.index("10v")
-                    curr = np.sqrt(pred[..., [Ix]] ** 2 + pred[..., [Iy]] ** 2)
-                    extra_pred += [curr]
-                else:
-                    raise ValueError(f"No recipe to compute {name}")
+                extr_vars, name, success = expr_to_var(name)
+                assert success, "Variables could not be extracted from expression"
+
+                variables_dict = {}
+                for v in extr_vars:
+                    idx = self.pm.variables.index(v)
+                    variables_dict[v] = pred[..., idx]
+                extra_pred += [safe_eval_expr(name, variables_dict)[...,None]]
 
             pred = np.concatenate([pred] + extra_pred, axis=2)
 

--- a/bris/outputs/__init__.py
+++ b/bris/outputs/__init__.py
@@ -7,7 +7,7 @@ import numpy as np
 from bris import sources
 from bris.predict_metadata import PredictMetadata
 from bris.utils import LOGGER
-from bris.utils import datetime_to_unixtime, safe_eval_expr, expr_to_var
+from bris.utils import datetime_to_unixtime, expr_to_var, safe_eval_expr
 
 
 def instantiate(name: str, predict_metadata: PredictMetadata, workdir: str, init_args):

--- a/bris/outputs/netcdf.py
+++ b/bris/outputs/netcdf.py
@@ -346,6 +346,7 @@ class Netcdf(Output):
             variable_index = self.pm.variables.index(variable)
             level_index = self.variable_list.get_level_index(variable)
             ncname = self.variable_list.get_ncname_from_anemoi_name(variable)
+            ncname = ncname.replace('[', '').replace(']', '').replace('*', '')
             if self.compression:
                 nc_encoding[ncname] = {"zlib": True}
 

--- a/bris/outputs/netcdf.py
+++ b/bris/outputs/netcdf.py
@@ -407,6 +407,7 @@ class Netcdf(Output):
             variable_index = self.pm.variables.index(variable)
             level_index = self.variable_list.get_level_index(variable)
             ncname = self.variable_list.get_ncname_from_anemoi_name(variable)
+            ncname = ncname.replace('[', '').replace(']', '').replace('*', '')
             if self.compression:
                 self.nc_encoding[ncname] = {"zlib": True}
 

--- a/bris/outputs/netcdf.py
+++ b/bris/outputs/netcdf.py
@@ -407,7 +407,7 @@ class Netcdf(Output):
             variable_index = self.pm.variables.index(variable)
             level_index = self.variable_list.get_level_index(variable)
             ncname = self.variable_list.get_ncname_from_anemoi_name(variable)
-            ncname = ncname.replace('[', '').replace(']', '').replace('*', '')
+            ncname = ncname.replace("[", "").replace("]", "").replace("*", "")
             if self.compression:
                 self.nc_encoding[ncname] = {"zlib": True}
 

--- a/bris/outputs/netcdf.py
+++ b/bris/outputs/netcdf.py
@@ -431,6 +431,7 @@ class Netcdf(Output):
             variable_index = self.pm.variables.index(variable)
             level_index = self.variable_list.get_level_index(variable)
             ncname = self.variable_list.get_ncname_from_anemoi_name(variable)
+            ncname = ncname.replace('[', '').replace(']', '').replace('*', '')
             if self.compression:
                 self.nc_encoding[ncname] = {"zlib": True}
 

--- a/bris/outputs/netcdf.py
+++ b/bris/outputs/netcdf.py
@@ -161,7 +161,7 @@ class Netcdf(Output):
         x: np.ndarray | None = None
         y: np.ndarray | None = None
 
-        t0 = pytime.perf_counter()
+        #t0 = pytime.perf_counter()
 
         # TODO: Seconds or hours for leadtimes?
         times_ut = utils.datetime_to_unixtime(times)
@@ -544,7 +544,7 @@ class Netcdf(Output):
         )
 
     def finalize(self):
-        t0 = pytime.perf_counter()
+        #t0 = pytime.perf_counter()
 
         if self.pm.num_members > 1:
             # Load data from the intermediate and write to disk

--- a/bris/outputs/netcdf.py
+++ b/bris/outputs/netcdf.py
@@ -431,7 +431,7 @@ class Netcdf(Output):
             variable_index = self.pm.variables.index(variable)
             level_index = self.variable_list.get_level_index(variable)
             ncname = self.variable_list.get_ncname_from_anemoi_name(variable)
-            ncname = ncname.replace('[', '').replace(']', '').replace('*', '')
+            ncname = ncname.replace("[", "").replace("]", "").replace("*", "")
             if self.compression:
                 self.nc_encoding[ncname] = {"zlib": True}
 

--- a/bris/outputs/netcdf.py
+++ b/bris/outputs/netcdf.py
@@ -161,7 +161,7 @@ class Netcdf(Output):
         x: np.ndarray | None = None
         y: np.ndarray | None = None
 
-        #t0 = pytime.perf_counter()
+        t0 = pytime.perf_counter()
 
         # TODO: Seconds or hours for leadtimes?
         times_ut = utils.datetime_to_unixtime(times)
@@ -544,7 +544,7 @@ class Netcdf(Output):
         )
 
     def finalize(self):
-        #t0 = pytime.perf_counter()
+        t0 = pytime.perf_counter()
 
         if self.pm.num_members > 1:
             # Load data from the intermediate and write to disk

--- a/bris/outputs/netcdf.py
+++ b/bris/outputs/netcdf.py
@@ -158,7 +158,7 @@ class Netcdf(Output):
         x: np.ndarray | None = None
         y: np.ndarray | None = None
 
-        t0 = pytime.perf_counter()
+        #t0 = pytime.perf_counter()
 
         # TODO: Seconds or hours for leadtimes?
         times_ut = utils.datetime_to_unixtime(times)
@@ -520,7 +520,7 @@ class Netcdf(Output):
         )
 
     def finalize(self):
-        t0 = pytime.perf_counter()
+        #t0 = pytime.perf_counter()
 
         if self.pm.num_members > 1:
             # Load data from the intermediate and write to disk

--- a/bris/outputs/netcdf.py
+++ b/bris/outputs/netcdf.py
@@ -158,7 +158,7 @@ class Netcdf(Output):
         x: np.ndarray | None = None
         y: np.ndarray | None = None
 
-        #t0 = pytime.perf_counter()
+        t0 = pytime.perf_counter()
 
         # TODO: Seconds or hours for leadtimes?
         times_ut = utils.datetime_to_unixtime(times)
@@ -520,7 +520,7 @@ class Netcdf(Output):
         )
 
     def finalize(self):
-        #t0 = pytime.perf_counter()
+        t0 = pytime.perf_counter()
 
         if self.pm.num_members > 1:
             # Load data from the intermediate and write to disk

--- a/bris/sources/anemoidataset.py
+++ b/bris/sources/anemoidataset.py
@@ -69,7 +69,7 @@ class AnemoiDataset(Source):
                 j = int(i[0])
                 if j in self.dataset.missing:
                     print(
-                        f"Date {self.dataset.dates[int(i[0])]} missing from verif dataset"
+                        f"Date {self.dataset.dates[j]} missing from verif dataset"
                     )
                 else:
                     if self.derive:

--- a/bris/sources/anemoidataset.py
+++ b/bris/sources/anemoidataset.py
@@ -20,18 +20,16 @@ class AnemoiDataset(Source):
         """
         Args:
             dataset_dict: open_dataset recipe, dictionary.
-            variable: variable to fetch from dataset. Can also specify how to 
+            variable: variable to fetch from dataset. Can also specify how to
                       derive from other variables using standard Pythonic math
                       expressions and specifying variables in brackets (e.g. [10u])
             every: include every this number of locations in the verif file
         """
         self.dataset = open_dataset(dataset_dict)
         self.variable, self.derive_variables, self.derive = resolve_var_expr(
-                variable, self.dataset.name_to_index
+            variable, self.dataset.name_to_index
         )
         self.every_loc = every_loc
-
-        
 
     @cached_property
     def locations(self):
@@ -67,9 +65,7 @@ class AnemoiDataset(Source):
             if len(i) > 0:
                 j = int(i[0])
                 if j in self.dataset.missing:
-                    print(
-                        f"Date {self.dataset.dates[j]} missing from verif dataset"
-                    )
+                    print(f"Date {self.dataset.dates[j]} missing from verif dataset")
                 else:
                     if self.derive:
                         variables_dict = {}
@@ -79,7 +75,10 @@ class AnemoiDataset(Source):
                         data[t, :] = safe_eval_expr(self.variable, variables_dict)
                     else:
                         data[t, :] = self.dataset[
-                            j, self.derive_variables[self.variable], 0, :: self.every_loc
+                            j,
+                            self.derive_variables[self.variable],
+                            0,
+                            :: self.every_loc,
                         ]
 
         observations = Observations(self.locations, requested_times, {variable: data})

--- a/bris/sources/anemoidataset.py
+++ b/bris/sources/anemoidataset.py
@@ -1,5 +1,5 @@
-from functools import cached_property
 import re
+from functools import cached_property
 
 import numpy as np
 from anemoi.datasets import open_dataset
@@ -7,8 +7,7 @@ from anemoi.datasets import open_dataset
 from bris.conventions.anemoi import get_units as get_anemoi_units
 from bris.observations import Location, Observations
 from bris.sources import Source
-from bris.utils import datetime_to_unixtime, safe_eval_expr, resolve_var_expr
-
+from bris.utils import datetime_to_unixtime, resolve_var_expr, safe_eval_expr
 
 
 class AnemoiDataset(Source):

--- a/bris/utils.py
+++ b/bris/utils.py
@@ -384,21 +384,8 @@ def expr_to_var(variable):
 def resolve_var_expr(variable, name_to_index):
     """
     Return complete variable list with dataset index
-
-    Args:
-        variable: str
-            Variable defined either directly or through expression
-        name_to_index: str
-            Dataset name to index
-
-    Returns:
-        variable: str
-            A potentially updated variable
-        derive_variables: dict
-            Name to index for the derived variable(s)
-        derive: bool
-            Whether or not to derive variable
     """
+
     variables, variable, derive = expr_to_var(variable)
     derive_variables = {v: name_to_index[v] for v in variables}
     return variable, derive_variables, derive

--- a/bris/utils.py
+++ b/bris/utils.py
@@ -340,9 +340,20 @@ def safe_eval_expr(expr, variables_dict):
     visitor = EvalVisitor()
     return visitor.visit(tree.body)
 
+def expr_to_var(variable):
+    """Extract variables from expression and return
+    complete variable list and whether or not to derive"""
+    if variable == "ws":
+        variable = "([10u]**2+[10v]**2)**0.5"
+    if "[" in variable:
+        return re.findall(r'\[([^\[\]]+)\]', variable), variable, True
+    return [variable], variable, False
+
 
 def resolve_var_expr(variable, name_to_index):
     """
+    Return complete variable list with dataset index
+
     Args:
         variable: str
             Variable defined either directly or through expression
@@ -357,13 +368,6 @@ def resolve_var_expr(variable, name_to_index):
         derive: bool
             Whether or not to derive variable
     """
-    if variable == "ws" and variable not in name_to_index.keys():
-        variable = "([10u]**2+[10v]**2)**0.5"
-   
-    if "[" in variable:
-        derive_variables = re.findall(r'\[([^\[\]]+)\]', variable)
-        derive_variables = {v: name_to_index[v] for v in derive_variables}
-        return variable, derive_variables, True
-    else:
-        derive_variables = {variable: name_to_index[variable]}
-        return variable, derive_variables, False
+    variables, variable, derive = expr_to_var(variable)
+    derive_variables = {v: name_to_index[v] for v in variables}
+    return variable, derive_variables, derive

--- a/bris/utils.py
+++ b/bris/utils.py
@@ -1,6 +1,9 @@
+import ast
+import operator as op
 import json
 import logging
 import numbers
+import re
 import os
 import sys
 import time
@@ -309,3 +312,89 @@ def get_all_leadtimes(
     )
 
     return np.concatenate([high_res, low_res])
+
+
+def safe_eval_expr(expr, variables_dict):
+    """
+    Safely evaluate a math expression like '[10u]**2 + [10v]**2' using AST.
+    """
+
+    allowed_operators = {
+        ast.Add: op.add,
+        ast.Sub: op.sub,
+        ast.Mult: op.mul,
+        ast.Div: op.truediv,
+        ast.Pow: op.pow,
+        ast.USub: op.neg,
+    }
+
+    class EvalVisitor(ast.NodeVisitor):
+        def visit_BinOp(self, node):
+            left = self.visit(node.left)
+            right = self.visit(node.right)
+            return allowed_operators[type(node.op)](left, right)
+
+        def visit_UnaryOp(self, node):
+            operand = self.visit(node.operand)
+            return allowed_operators[type(node.op)](operand)
+
+        def visit_Name(self, node):
+            if node.id in safe_variables:
+                return safe_variables[node.id]
+            else:
+                raise ValueError(f"Unknown variable: {node.id}")
+
+        def visit_Expr(self, node):
+            return self.visit(node.value)
+
+        def visit_Call(self, node):
+            raise ValueError("Function calls not allowed")
+
+        def visit_Num(self, node):
+            return node.n
+
+        def visit_Constant(self, node):  # Python 3.8+
+            return node.value
+
+    # map to safe names
+    safe_variables = {}
+    for i, original_name in enumerate(variables_dict.keys()):
+        safe_name = f"var_{i}"
+        safe_variables[safe_name] = variables_dict[original_name]
+
+    # Replace all occurrences of original names in expression with safe names
+    expr_safe = expr
+    for original_name, safe_name in zip(variables_dict.keys(), safe_variables.keys()):
+        expr_safe = expr_safe.replace(f"[{original_name}]", safe_name)
+
+    tree = ast.parse(expr_safe, mode='eval')
+    visitor = EvalVisitor()
+    return visitor.visit(tree.body)
+
+
+def resolve_var_expr(variable, name_to_index):
+    """
+    Args:
+        variable: str
+            Variable defined either directly or through expression
+        name_to_index: str
+            Dataset name to index
+
+    Returns:
+        variable: str
+            A potentially updated variable
+        derive_variables: dict
+            Name to index for the derived variable(s)
+        derive: bool
+            Whether or not to derive variable
+    """
+    if variable == "ws" and variable not in name_to_index.keys():
+        variable = "([10u]**2+[10v]**2)**0.5"
+   
+    if "[" in variable:
+        derive_variables = re.findall(r'\[([^\[\]]+)\]', variable)
+        derive_variables = {v: name_to_index[v] for v in derive_variables}
+        return variable, derive_variables, True
+    else:
+        derive_variables = {variable: name_to_index[variable]}
+        return variable, derive_variables, False

--- a/bris/utils.py
+++ b/bris/utils.py
@@ -384,8 +384,21 @@ def expr_to_var(variable):
 def resolve_var_expr(variable, name_to_index):
     """
     Return complete variable list with dataset index
-    """
 
+    Args:
+        variable: str
+            Variable defined either directly or through expression
+        name_to_index: str
+            Dataset name to index
+
+    Returns:
+        variable: str
+            A potentially updated variable
+        derive_variables: dict
+            Name to index for the derived variable(s)
+        derive: bool
+            Whether or not to derive variable
+    """
     variables, variable, derive = expr_to_var(variable)
     derive_variables = {v: name_to_index[v] for v in variables}
     return variable, derive_variables, derive

--- a/bris/utils.py
+++ b/bris/utils.py
@@ -1,6 +1,9 @@
+import ast
+import operator as op
 import json
 import logging
 import numbers
+import re
 import os
 import time
 import uuid
@@ -281,3 +284,89 @@ def get_all_leadtimes(
     )
 
     return np.concatenate([high_res, low_res])
+
+
+def safe_eval_expr(expr, variables_dict):
+    """
+    Safely evaluate a math expression like '[10u]**2 + [10v]**2' using AST.
+    """
+
+    allowed_operators = {
+        ast.Add: op.add,
+        ast.Sub: op.sub,
+        ast.Mult: op.mul,
+        ast.Div: op.truediv,
+        ast.Pow: op.pow,
+        ast.USub: op.neg,
+    }
+
+    class EvalVisitor(ast.NodeVisitor):
+        def visit_BinOp(self, node):
+            left = self.visit(node.left)
+            right = self.visit(node.right)
+            return allowed_operators[type(node.op)](left, right)
+
+        def visit_UnaryOp(self, node):
+            operand = self.visit(node.operand)
+            return allowed_operators[type(node.op)](operand)
+
+        def visit_Name(self, node):
+            if node.id in safe_variables:
+                return safe_variables[node.id]
+            else:
+                raise ValueError(f"Unknown variable: {node.id}")
+
+        def visit_Expr(self, node):
+            return self.visit(node.value)
+
+        def visit_Call(self, node):
+            raise ValueError("Function calls not allowed")
+
+        def visit_Num(self, node):
+            return node.n
+
+        def visit_Constant(self, node):  # Python 3.8+
+            return node.value
+
+    # map to safe names
+    safe_variables = {}
+    for i, original_name in enumerate(variables_dict.keys()):
+        safe_name = f"var_{i}"
+        safe_variables[safe_name] = variables_dict[original_name]
+
+    # Replace all occurrences of original names in expression with safe names
+    expr_safe = expr
+    for original_name, safe_name in zip(variables_dict.keys(), safe_variables.keys()):
+        expr_safe = expr_safe.replace(f"[{original_name}]", safe_name)
+
+    tree = ast.parse(expr_safe, mode='eval')
+    visitor = EvalVisitor()
+    return visitor.visit(tree.body)
+
+
+def resolve_var_expr(variable, name_to_index):
+    """
+    Args:
+        variable: str
+            Variable defined either directly or through expression
+        name_to_index: str
+            Dataset name to index
+
+    Returns:
+        variable: str
+            A potentially updated variable
+        derive_variables: dict
+            Name to index for the derived variable(s)
+        derive: bool
+            Whether or not to derive variable
+    """
+    if variable == "ws" and variable not in name_to_index.keys():
+        variable = "([10u]**2+[10v]**2)**0.5"
+   
+    if "[" in variable:
+        derive_variables = re.findall(r'\[([^\[\]]+)\]', variable)
+        derive_variables = {v: name_to_index[v] for v in derive_variables}
+        return variable, derive_variables, True
+    else:
+        derive_variables = {variable: name_to_index[variable]}
+        return variable, derive_variables, False

--- a/bris/utils.py
+++ b/bris/utils.py
@@ -343,9 +343,20 @@ def safe_eval_expr(expr, variables_dict):
     visitor = EvalVisitor()
     return visitor.visit(tree.body)
 
+def expr_to_var(variable):
+    """Extract variables from expression and return
+    complete variable list and whether or not to derive"""
+    if variable == "ws":
+        variable = "([10u]**2+[10v]**2)**0.5"
+    if "[" in variable:
+        return re.findall(r'\[([^\[\]]+)\]', variable), variable, True
+    return [variable], variable, False
+
 
 def resolve_var_expr(variable, name_to_index):
     """
+    Return complete variable list with dataset index
+
     Args:
         variable: str
             Variable defined either directly or through expression
@@ -360,13 +371,6 @@ def resolve_var_expr(variable, name_to_index):
         derive: bool
             Whether or not to derive variable
     """
-    if variable == "ws" and variable not in name_to_index.keys():
-        variable = "([10u]**2+[10v]**2)**0.5"
-   
-    if "[" in variable:
-        derive_variables = re.findall(r'\[([^\[\]]+)\]', variable)
-        derive_variables = {v: name_to_index[v] for v in derive_variables}
-        return variable, derive_variables, True
-    else:
-        derive_variables = {variable: name_to_index[variable]}
-        return variable, derive_variables, False
+    variables, variable, derive = expr_to_var(variable)
+    derive_variables = {v: name_to_index[v] for v in variables}
+    return variable, derive_variables, derive

--- a/bris/utils.py
+++ b/bris/utils.py
@@ -370,9 +370,10 @@ def safe_eval_expr(expr, variables_dict):
     for original_name, safe_name in zip(variables_dict.keys(), safe_variables.keys()):
         expr_safe = expr_safe.replace(f"[{original_name}]", safe_name)
 
-    tree = ast.parse(expr_safe, mode='eval')
+    tree = ast.parse(expr_safe, mode="eval")
     visitor = EvalVisitor()
     return visitor.visit(tree.body)
+
 
 def expr_to_var(variable):
     """Extract variables from expression and return
@@ -380,7 +381,7 @@ def expr_to_var(variable):
     if variable == "ws":
         variable = "([10u]**2+[10v]**2)**0.5"
     if "[" in variable:
-        return re.findall(r'\[([^\[\]]+)\]', variable), variable, True
+        return re.findall(r"\[([^\[\]]+)\]", variable), variable, True
     return [variable], variable, False
 
 

--- a/bris/utils.py
+++ b/bris/utils.py
@@ -339,9 +339,10 @@ def safe_eval_expr(expr, variables_dict):
     for original_name, safe_name in zip(variables_dict.keys(), safe_variables.keys()):
         expr_safe = expr_safe.replace(f"[{original_name}]", safe_name)
 
-    tree = ast.parse(expr_safe, mode='eval')
+    tree = ast.parse(expr_safe, mode="eval")
     visitor = EvalVisitor()
     return visitor.visit(tree.body)
+
 
 def expr_to_var(variable):
     """Extract variables from expression and return
@@ -349,7 +350,7 @@ def expr_to_var(variable):
     if variable == "ws":
         variable = "([10u]**2+[10v]**2)**0.5"
     if "[" in variable:
-        return re.findall(r'\[([^\[\]]+)\]', variable), variable, True
+        return re.findall(r"\[([^\[\]]+)\]", variable), variable, True
     return [variable], variable, False
 
 

--- a/bris/utils.py
+++ b/bris/utils.py
@@ -1,6 +1,9 @@
+import ast
+import operator as op
 import json
 import logging
 import numbers
+import re
 import os
 import time
 import uuid
@@ -278,3 +281,89 @@ def get_all_leadtimes(
     )
 
     return np.concatenate([high_res, low_res])
+
+
+def safe_eval_expr(expr, variables_dict):
+    """
+    Safely evaluate a math expression like '[10u]**2 + [10v]**2' using AST.
+    """
+
+    allowed_operators = {
+        ast.Add: op.add,
+        ast.Sub: op.sub,
+        ast.Mult: op.mul,
+        ast.Div: op.truediv,
+        ast.Pow: op.pow,
+        ast.USub: op.neg,
+    }
+
+    class EvalVisitor(ast.NodeVisitor):
+        def visit_BinOp(self, node):
+            left = self.visit(node.left)
+            right = self.visit(node.right)
+            return allowed_operators[type(node.op)](left, right)
+
+        def visit_UnaryOp(self, node):
+            operand = self.visit(node.operand)
+            return allowed_operators[type(node.op)](operand)
+
+        def visit_Name(self, node):
+            if node.id in safe_variables:
+                return safe_variables[node.id]
+            else:
+                raise ValueError(f"Unknown variable: {node.id}")
+
+        def visit_Expr(self, node):
+            return self.visit(node.value)
+
+        def visit_Call(self, node):
+            raise ValueError("Function calls not allowed")
+
+        def visit_Num(self, node):
+            return node.n
+
+        def visit_Constant(self, node):  # Python 3.8+
+            return node.value
+
+    # map to safe names
+    safe_variables = {}
+    for i, original_name in enumerate(variables_dict.keys()):
+        safe_name = f"var_{i}"
+        safe_variables[safe_name] = variables_dict[original_name]
+
+    # Replace all occurrences of original names in expression with safe names
+    expr_safe = expr
+    for original_name, safe_name in zip(variables_dict.keys(), safe_variables.keys()):
+        expr_safe = expr_safe.replace(f"[{original_name}]", safe_name)
+
+    tree = ast.parse(expr_safe, mode='eval')
+    visitor = EvalVisitor()
+    return visitor.visit(tree.body)
+
+
+def resolve_var_expr(variable, name_to_index):
+    """
+    Args:
+        variable: str
+            Variable defined either directly or through expression
+        name_to_index: str
+            Dataset name to index
+
+    Returns:
+        variable: str
+            A potentially updated variable
+        derive_variables: dict
+            Name to index for the derived variable(s)
+        derive: bool
+            Whether or not to derive variable
+    """
+    if variable == "ws" and variable not in name_to_index.keys():
+        variable = "([10u]**2+[10v]**2)**0.5"
+   
+    if "[" in variable:
+        derive_variables = re.findall(r'\[([^\[\]]+)\]', variable)
+        derive_variables = {v: name_to_index[v] for v in derive_variables}
+        return variable, derive_variables, True
+    else:
+        derive_variables = {variable: name_to_index[variable]}
+        return variable, derive_variables, False

--- a/bris/utils.py
+++ b/bris/utils.py
@@ -1,11 +1,14 @@
 import ast
-import operator as op
 import json
 import logging
 import numbers
-import re
+import operator as op
 import os
+<<<<<<< HEAD
 import sys
+=======
+import re
+>>>>>>> a9d0003 (Ruff)
 import time
 import uuid
 from argparse import ArgumentParser

--- a/bris/utils.py
+++ b/bris/utils.py
@@ -1,10 +1,10 @@
 import ast
-import operator as op
 import json
 import logging
 import numbers
-import re
+import operator as op
 import os
+import re
 import time
 import uuid
 from argparse import ArgumentParser

--- a/bris/utils.py
+++ b/bris/utils.py
@@ -371,9 +371,20 @@ def safe_eval_expr(expr, variables_dict):
     visitor = EvalVisitor()
     return visitor.visit(tree.body)
 
+def expr_to_var(variable):
+    """Extract variables from expression and return
+    complete variable list and whether or not to derive"""
+    if variable == "ws":
+        variable = "([10u]**2+[10v]**2)**0.5"
+    if "[" in variable:
+        return re.findall(r'\[([^\[\]]+)\]', variable), variable, True
+    return [variable], variable, False
+
 
 def resolve_var_expr(variable, name_to_index):
     """
+    Return complete variable list with dataset index
+
     Args:
         variable: str
             Variable defined either directly or through expression
@@ -388,13 +399,6 @@ def resolve_var_expr(variable, name_to_index):
         derive: bool
             Whether or not to derive variable
     """
-    if variable == "ws" and variable not in name_to_index.keys():
-        variable = "([10u]**2+[10v]**2)**0.5"
-   
-    if "[" in variable:
-        derive_variables = re.findall(r'\[([^\[\]]+)\]', variable)
-        derive_variables = {v: name_to_index[v] for v in derive_variables}
-        return variable, derive_variables, True
-    else:
-        derive_variables = {variable: name_to_index[variable]}
-        return variable, derive_variables, False
+    variables, variable, derive = expr_to_var(variable)
+    derive_variables = {v: name_to_index[v] for v in variables}
+    return variable, derive_variables, derive


### PR DESCRIPTION
Added support for:
- defining variables from expressions
- `ws` is automatically converted to the expression "([10u]**2+[10v]**2)**0.5"

Variables expressions support basic math operators, and expression mode is invkoed if there is a left braket '[' in the variable definition:

Example:

``` yaml
- verif:
          filename: /path/to/output.nc
          variable: ws
          units: m/s
          obs_sources:
            - anemoidataset:
                dataset: ${verif_dataset}
                variable: "([10u]**2+[10v]**2)**0.5"
```

This functionality was also incorporated into the NetCDF output class, here demonstrated by converting total cloud coverage (tcc) from the range 0-1 to 0-100:

``` yaml
- netcdf:
    filename_pattern: /path/to/output.nc
    variables: [2t, msl]
    extra_variables: ["100*[tcc]"]

```
