### PR TITLE
Wind speed in anemoidatasets verif outputs

### DIFF
--- a/bris/sources/anemoidataset.py
+++ b/bris/sources/anemoidataset.py
@@ -26,7 +26,9 @@ class AnemoiDataset(Source):
         self.dataset = open_dataset(dataset_dict)
         self.variable = variable
         if variable == "ws":
-            self.variable_index = [self.dataset.name_to_index[v] for v in ["10u", "10v"]]
+            self.variable_index = [
+                self.dataset.name_to_index[v] for v in ["10u", "10v"]
+            ]
         else:
             self.variable_index = self.dataset.name_to_index[variable]
         self.every_loc = every_loc
@@ -69,9 +71,13 @@ class AnemoiDataset(Source):
                     )
                 else:
                     if self.variable == "ws":
-                        data_u = self.dataset[int(i[0]), self.variable_index[0], 0, :: self.every_loc]
-                        data_v = self.dataset[int(i[0]), self.variable_index[1], 0, :: self.every_loc]
-                        data[t, :] = (data_u**2+data_v**2)**0.5
+                        data_u = self.dataset[
+                            int(i[0]), self.variable_index[0], 0, :: self.every_loc
+                        ]
+                        data_v = self.dataset[
+                            int(i[0]), self.variable_index[1], 0, :: self.every_loc
+                        ]
+                        data[t, :] = (data_u**2 + data_v**2) ** 0.5
                     else:
                         data[t, :] = self.dataset[
                             int(i[0]), self.variable_index, 0, :: self.every_loc


### PR DESCRIPTION
Implemented extra variables (wind speed) when using anemoidatasets as verif source:

```yml

routing:
  - decoder_index: 0
    domain_index: 0
    outputs:
      - verif:
          filename: /path/to/outfile.nc
          variable: ws
          units: m/s
          obs_sources:
            - anemoidataset:
                dataset: /path/to/anemoidataset.zarr
                variable: ws
```