### PR TITLE
Remove inplace unit conversion

### DIFF
--- a/bris/conventions/anemoi.py
+++ b/bris/conventions/anemoi.py
@@ -10,7 +10,7 @@ def get_units(name: str) -> str | None:
     units = attrs.get("units", None)
 
     # Here's an opportunity to override, if needed:
-    if name == "tp":
+    if name in ["tp", "tp_acc"]:
         return "Mg/m^2"
 
     return units

--- a/bris/outputs/netcdf.py
+++ b/bris/outputs/netcdf.py
@@ -529,7 +529,7 @@ class Netcdf(Output):
             from_units = anemoi_conventions.get_units(variable)
             if "units" in attrs:
                 to_units = attrs["units"]
-                bris.units.convert(ar, from_units, to_units, inplace=True)
+                ar, _ = bris.units.convert(ar, from_units, to_units, inplace=False)
 
             if level_index is not None:
                 self.ds[ncname][:, level_index, ...] = ar


### PR DESCRIPTION
Gives "tp_acc" correct units. Removes inplace unit conversion since multiple outputs can use a common model-output and we only want to scale/convert once. 