### PR TITLE
Change name of ensemble fields in verif output

### DIFF
--- a/bris/outputs/verif.py
+++ b/bris/outputs/verif.py
@@ -281,6 +281,7 @@ class Verif(Output):
         )
         fcst = self.create_nan_array(fcst_shape)
         ens_mean = self.create_nan_array(fcst_shape)
+        ens_var = self.create_nan_array(fcst_shape)
         ens = self.create_nan_array(fcst_shape + (self.num_members,))
         for i, frt in enumerate(frts):
             curr = self.intermediate.get_forecast(frt)[..., 0, :]
@@ -288,6 +289,7 @@ class Verif(Output):
             if self.num_members > 1:
                 ens[i, ...] = curr
                 ens_mean[i, ...] = curr.mean(axis=-1)
+                ens_var[i, ...] = curr.var(axis=-1)
 
         if self.variable_type in ["logit", "threshold_probability"]:
             cdf = np.copy(fcst)
@@ -309,6 +311,7 @@ class Verif(Output):
                     ens,
                 )
                 self.ds["ensemble_mean"] = (["time", "leadtime", "location"], ens_mean)
+                self.ds["ensemble_variance"] = (["time", "leadtime", "location"], ens_var)
             # Load threshold forecasts
             if len(self.thresholds) > 0 and self.num_members > 1:
                 cdf = self.create_nan_array(fcst_shape + (len(self.thresholds),))
@@ -396,6 +399,7 @@ class Verif(Output):
             "fcst",
             "ensemble",
             "ensemble_mean",
+            "ensemble_variance",
             "cdf",
             "x",
             "ensemble_crps",

--- a/bris/outputs/verif.py
+++ b/bris/outputs/verif.py
@@ -308,7 +308,7 @@ class Verif(Output):
                     ["time", "leadtime", "location", "ensemble_member"],
                     ens,
                 )
-                self.ds["ens-mean"] = (["time", "leadtime", "location"], ens_mean)
+                self.ds["ensemble_mean"] = (["time", "leadtime", "location"], ens_mean)
             # Load threshold forecasts
             if len(self.thresholds) > 0 and self.num_members > 1:
                 cdf = self.create_nan_array(fcst_shape + (len(self.thresholds),))
@@ -383,7 +383,7 @@ class Verif(Output):
 
         if self.num_members > 1:
             crps = self.compute_crps(ens, obs, self.fair_crps)
-            self.ds["crps"] = (["time", "leadtime", "location"], crps)
+            self.ds["ensemble_crps"] = (["time", "leadtime", "location"], crps)
 
         self.ds.attrs["units"] = self.units
         self.ds.attrs["verif_version"] = "1.0.0"
@@ -395,10 +395,10 @@ class Verif(Output):
             "obs",
             "fcst",
             "ensemble",
-            "ens-mean",
+            "ensemble_mean",
             "cdf",
             "x",
-            "crps",
+            "ensemble_crps",
             "pit",
         ]
         if self.compression:

--- a/bris/outputs/verif.py
+++ b/bris/outputs/verif.py
@@ -311,7 +311,10 @@ class Verif(Output):
                     ens,
                 )
                 self.ds["ensemble_mean"] = (["time", "leadtime", "location"], ens_mean)
-                self.ds["ensemble_variance"] = (["time", "leadtime", "location"], ens_var)
+                self.ds["ensemble_variance"] = (
+                    ["time", "leadtime", "location"],
+                    ens_var,
+                )
             # Load threshold forecasts
             if len(self.thresholds) > 0 and self.num_members > 1:
                 cdf = self.create_nan_array(fcst_shape + (len(self.thresholds),))


### PR DESCRIPTION
In the newest version of verif, `ens-mean` and `crps` correspond to the on-the-fly computed ensemble mean and continue ranked probability score, respectively. To not conflict with this, we rename those fields in bris-inference:

- `ens-mean` -> `ensemble_mean`
- `crps` -> `ensemble_crps`

