### PR TITLE
Feature/spectral spreadskill

### DIFF
--- a/bris/conventions/cf.py
+++ b/bris/conventions/cf.py
@@ -176,6 +176,14 @@ def get_attributes(cfname: str) -> dict[str, str] | dict:
             "long_name": "Surface (skin) temperature (SKT)",
             "units": "K",
         },
+        "k": {
+            "long_name": "Wavenumber",
+            "units": "1/m",
+        },
+        "wavelength": {
+            "long_name": "Wavelength",
+            "units": "m",
+        },
     }
 
     # Return empty dictionary if unknown

--- a/bris/outputs/__init__.py
+++ b/bris/outputs/__init__.py
@@ -41,6 +41,9 @@ def instantiate(name: str, predict_metadata: PredictMetadata, workdir: str, init
     if name == "powerspectrum_gridded":
         return DCTPowerSpectrum(predict_metadata, workdir, **init_args)
 
+    if name == "spectral_spread_skill":
+        return SpectralSkillSpread(predict_metadata, workdir, **init_args)
+
     raise ValueError(f"Invalid output: {name}")
 
 
@@ -64,7 +67,7 @@ def get_required_variables(name, init_args):
             return variables
         return [None]
 
-    if name in ["verif", "powerspectrum_gridded", "powerspectrum_global"]:
+    if name in ["verif", "powerspectrum_gridded", "powerspectrum_global", "spectral_spread_skill"]:
         if init_args["variable"] == "ws":
             return ["10u", "10v"]
         return [init_args["variable"]]
@@ -199,4 +202,5 @@ from .grib import Grib
 from .intermediate import Intermediate
 from .netcdf import Netcdf
 from .spatial import DCTPowerSpectrum, SHPowerSpectrum
+from .spectral import SpectralSkillSpread
 from .verif import Verif

--- a/bris/outputs/__init__.py
+++ b/bris/outputs/__init__.py
@@ -41,8 +41,8 @@ def instantiate(name: str, predict_metadata: PredictMetadata, workdir: str, init
     if name == "powerspectrum_gridded":
         return DCTPowerSpectrum(predict_metadata, workdir, **init_args)
 
-    if name == "spectral_spread_skill":
-        return SpectralSkillSpread(predict_metadata, workdir, **init_args)
+    if name == "spectral_gridded":
+        return SpectralGridded(predict_metadata, workdir, **init_args)
 
     raise ValueError(f"Invalid output: {name}")
 
@@ -67,7 +67,12 @@ def get_required_variables(name, init_args):
             return variables
         return [None]
 
-    if name in ["verif", "powerspectrum_gridded", "powerspectrum_global", "spectral_spread_skill"]:
+    if name in [
+        "verif",
+        "powerspectrum_gridded",
+        "powerspectrum_global",
+        "spectral_gridded",
+    ]:
         if init_args["variable"] == "ws":
             return ["10u", "10v"]
         return [init_args["variable"]]
@@ -202,5 +207,5 @@ from .grib import Grib
 from .intermediate import Intermediate
 from .netcdf import Netcdf
 from .spatial import DCTPowerSpectrum, SHPowerSpectrum
-from .spectral import SpectralSkillSpread
+from .spectral import SpectralGridded
 from .verif import Verif

--- a/bris/outputs/spectral.py
+++ b/bris/outputs/spectral.py
@@ -1,16 +1,17 @@
-import numpy as np
-from functools import cached_property
-from abc import abstractmethod
-from scipy.fft import dctn
-import xarray as xr
 import datetime
+from abc import abstractmethod
+from functools import cached_property
+
+import numpy as np
+import xarray as xr
+from anemoi.datasets import open_dataset
+from scipy.fft import dctn
 
 from bris import projections, utils
 from bris.conventions import cf
 from bris.outputs import Output
-from bris.predict_metadata import PredictMetadata
 from bris.outputs.intermediate import IntermediateSpatial
-from anemoi.datasets import open_dataset
+from bris.predict_metadata import PredictMetadata
 
 
 class SpectralGridded:
@@ -89,14 +90,8 @@ class SpectralGridded:
         """Calculates skill, spread and spectra in spectral space and writes to file."""
         nx, ny = self.pm.field_shape
 
-        _skill = np.zeros((self.pm.num_leadtimes, nx, ny))
-        spread = np.zeros((self.pm.num_leadtimes, nx, ny))
-
         frts = self.intermediate.get_forecast_reference_times()
-        print("frts:", frts)
-        N_t = len(frts)
         N = self.pm.num_members
-        print("N_t:", N_t, "N:", N)
 
         k_edges, k_bins, k = self.get_bins
         n_bins = k_bins.shape[0]

--- a/bris/outputs/spectral.py
+++ b/bris/outputs/spectral.py
@@ -13,8 +13,14 @@ from bris.outputs.intermediate import IntermediateSpatial
 from anemoi.datasets import open_dataset
 
 
-class SpectralSkillSpread():
-    """Calculates skill and spread on different length scales using the Discrete Cosine Transform (DCT)"""
+class SpectralGridded:
+    """Calculates quantities in spectral space using the Discrete Cosine Transform (DCT).
+    - Error variance: Variance of the error between the ensemble members and the analysis in spectral space.
+    - Spread variance: Variance of the ensemble members around the ensemble mean in spectral space.
+    - Spectrum of the forecast and observation: Average power in spectral space for the forecast and observation.
+
+    Writes to a file as a function of time, leadtime, wavenumber and ensemblemember (when relevant).
+    """
 
     def __init__(
         self,
@@ -31,7 +37,7 @@ class SpectralSkillSpread():
         extra_variables = []
         if variable not in predict_metadata.variables:
             extra_variables += [variable]
-        
+
         self.pm = predict_metadata
         if domain_name is not None:
             self.proj4_str = projections.get_proj4_str(domain_name)
@@ -39,11 +45,11 @@ class SpectralSkillSpread():
             self.proj4_str = proj4_str
         self.variable = variable
         self.filename = filename
-        shape = (predict_metadata.num_points)
+        shape = predict_metadata.num_points
         self.intermediate = IntermediateSpatial(
             predict_metadata=predict_metadata,
             workdir=workdir,
-            metric_shape = shape,
+            metric_shape=shape,
             extra_variables=extra_variables,
         )
         self.remove_intermediate = remove_intermediate
@@ -52,8 +58,12 @@ class SpectralSkillSpread():
         self.obs_dataset = open_dataset(obs_dataset)
 
     def get_observations_for_valid_times(self, frt: np.datetime64) -> np.ndarray:
+        """Retrieves observations for the valid times corresponding to the forecast reference time (frt) and leadtimes."""
+
         valid_times = [frt + np.timedelta64(lt, "s") for lt in self.pm.leadtimes]
-        time_indices = [np.argmin(np.abs(self.obs_dataset.dates - t)) for t in valid_times]
+        time_indices = [
+            np.argmin(np.abs(self.obs_dataset.dates - t)) for t in valid_times
+        ]
         if self.variable == "ws":
             u_index = self.obs_dataset.name_to_index["10u"]
             v_index = self.obs_dataset.name_to_index["10v"]
@@ -62,107 +72,162 @@ class SpectralSkillSpread():
             return np.sqrt(u**2 + v**2)
 
         var_index = self.obs_dataset.name_to_index[self.variable]
-        #Debug
-        print("valid_times: ", valid_times)
-        print("time_indices: ", time_indices)
         return self.obs_dataset[time_indices, var_index, 0, ...]
 
-    def add_forecast(
-        self, times: list, ensemble_member: int, pred: np.ndarray
-    ) -> None:
+    def add_forecast(self, times: list, ensemble_member: int, pred: np.ndarray) -> None:
+        """Adds forecast to intermediate storage. If variable is "ws", calculates wind speed from u and v components."""
         if self.variable == "ws":
             Ix = self.pm.variables.index("10u")
             Iy = self.pm.variables.index("10v")
             pred = np.sqrt(pred[..., [Ix]] ** 2 + pred[..., [Iy]] ** 2)
         else:
             pred = pred[..., [self.pm.variables.index(self.variable)]]
-        
+
         self.intermediate._add_forecast(times, ensemble_member, pred)
 
     def finalize(self) -> None:
-        """ Calculate skill spread and write to file"""
+        """Calculates skill, spread and spectra in spectral space and writes to file."""
         nx, ny = self.pm.field_shape
 
         _skill = np.zeros((self.pm.num_leadtimes, nx, ny))
         spread = np.zeros((self.pm.num_leadtimes, nx, ny))
-        
+
         frts = self.intermediate.get_forecast_reference_times()
+        print("frts:", frts)
         N_t = len(frts)
         N = self.pm.num_members
-
-        for frt in frts:
-            pred = np.zeros((self.pm.num_leadtimes, self.pm.num_points, self.pm.num_members))
-            for member in range(self.pm.num_members):
-                pred[..., member] = self.intermediate.get_forecast(frt, member).squeeze(-1)
-            
-            # Calculate skill
-            obs = self.get_observations_for_valid_times(frt) #(time, latlon)
-            
-            obs = obs.reshape(obs.shape[0], nx, ny) #(lt, x, y)
-            pred = pred.reshape(pred.shape[0], nx, ny, pred.shape[2]) #(lt, x, y, ens)
-
-            obs_k = dctn(obs, axes=(1,2), type=2, norm="ortho") #time, kx, ky
-            pred_k = dctn(pred, axes=(1,2), type=2, norm="ortho") #time, kx, ky, ens
-
-            ens_mean = pred_k.mean(axis=3) / N
-            
-            _skill += (ens_mean - obs_k)**2 / N_t
-            spread += np.sqrt( ( (pred_k - ens_mean[..., None])**2).sum(axis=3) / (N-1) ) / N_t
-
-        skill = np.sqrt(_skill)
+        print("N_t:", N_t, "N:", N)
 
         k_edges, k_bins, k = self.get_bins
         n_bins = k_bins.shape[0]
         digitized = np.digitize(k.flatten(), k_edges)
 
-        skill_k = np.full((self.pm.num_leadtimes, n_bins), np.nan)
-        spread_k = np.full((self.pm.num_leadtimes, n_bins), np.nan)
-
-        for lt in range(self.pm.num_leadtimes):
-            skill_k[lt] = np.array(
-                [
-                    skill[lt].flatten()[digitized == i].mean() if np.any(digitized == i) else 0 
-                    for i in range(1, n_bins + 1)
-                ]
+        spread_variance = np.full((len(frts), self.pm.num_leadtimes, n_bins), np.nan)
+        error_variance = np.full((len(frts), self.pm.num_leadtimes, n_bins), np.nan)
+        spectrum_forecast = np.full(
+            (len(frts), self.pm.num_leadtimes, n_bins, N), np.nan
+        )
+        spectrum_observation = np.full(
+            (len(frts), self.pm.num_leadtimes, n_bins), np.nan
+        )
+        for i, frt in enumerate(frts):
+            pred = np.zeros(
+                (self.pm.num_leadtimes, self.pm.num_points, self.pm.num_members)
             )
-            spread_k[lt] = np.array(
-                [
-                    spread[lt].flatten()[digitized == i].mean() if np.any(digitized == i) else 0 
-                    for i in range(1, n_bins + 1)
-                ]
-            )
+            for member in range(self.pm.num_members):
+                pred[..., member] = self.intermediate.get_forecast(frt, member).squeeze(
+                    -1
+                )
 
-        self.write(spread_k, skill_k, k_bins)
+            # Calculate skill
+            obs = self.get_observations_for_valid_times(frt)  # (time, latlon)
+
+            obs = obs.reshape(obs.shape[0], nx, ny)  # (lt, x, y)
+            pred = pred.reshape(pred.shape[0], nx, ny, pred.shape[2])  # (lt, x, y, ens)
+
+            obs_k = dctn(obs, axes=(1, 2), type=2, norm="ortho")  # time, kx, ky
+            pred_k = dctn(pred, axes=(1, 2), type=2, norm="ortho")  # time, kx, ky, ens
+
+            P_obs = np.abs(obs_k) ** 2
+            P_pred = np.abs(pred_k) ** 2
+
+            ens_mean = pred_k.mean(axis=3)
+
+            spread_variance_k = ((pred_k - ens_mean[..., None]) ** 2).sum(axis=3) / (
+                N - 1
+            )  # time, kx, ky
+            error_variance_k = (ens_mean - obs_k) ** 2  # time, kx, ky
+
+            # Bin average over k space
+            for lt in range(self.pm.num_leadtimes):
+                spread_variance[i, lt, :] = np.array(
+                    [
+                        spread_variance_k[lt].flatten()[digitized == j].mean()
+                        if np.any(digitized == j)
+                        else np.nan
+                        for j in range(1, n_bins + 1)
+                    ]
+                )
+                error_variance[i, lt, :] = np.array(
+                    [
+                        error_variance_k[lt].flatten()[digitized == j].mean()
+                        if np.any(digitized == j)
+                        else np.nan
+                        for j in range(1, n_bins + 1)
+                    ]
+                )
+                spectrum_forecast[i, lt, :, :] = np.array(
+                    [
+                        P_pred[lt].reshape(-1, N)[digitized == j, :].mean(axis=0)
+                        if np.any(digitized == j)
+                        else np.full(N, np.nan)
+                        for j in range(1, n_bins + 1)
+                    ]
+                )
+                spectrum_observation[i, lt, :] = np.array(
+                    [
+                        P_obs[lt].flatten()[digitized == j].mean()
+                        if np.any(digitized == j)
+                        else np.nan
+                        for j in range(1, n_bins + 1)
+                    ]
+                )
+
+        self.write(
+            spread_variance,
+            error_variance,
+            spectrum_forecast,
+            spectrum_observation,
+            k_bins,
+        )
         if self.remove_intermediate:
             self.intermediate.cleanup()
 
-    def write(self, spread_k: np.ndarray, skill_k: np.ndarray, k_bin: np.ndarray) -> None:
+    def write(
+        self,
+        spread_variance: np.ndarray,
+        error_variance: np.ndarray,
+        spectrum_forecast: np.ndarray,
+        spectrum_observation: np.ndarray,
+        k_bin: np.ndarray,
+    ) -> None:
         """Writes output to file"""
         coords = {}
+        frts = self.intermediate.get_forecast_reference_times()
+        times_unix = utils.datetime_to_unixtime(frts).astype(np.double)
+        coords["time"] = (["time"], times_unix, cf.get_attributes("time"))
 
         coords["leadtime"] = (
             ["leadtime"],
             self.intermediate.pm.leadtimes.astype(np.float32) / 3600,
             {"units": "hour"},
         )
-        coords["k"] = (
+        coords["k"] = (["k"], k_bin, cf.get_attributes("k"))
+        coords["wavelength"] = (
             ["k"],
-            k_bin,
-            cf.get_attributes("k")
+            2 * np.pi / k_bin,
+            cf.get_attributes("wavelength"),
         )
-        #TODO: convert from k to wavelength and add wavelength as a coordinate
+        coords["ensemble_member"] = (
+            ["ensemble_member"],
+            np.arange(self.pm.num_members),
+            cf.get_attributes("ensemble_member"),
+        )
 
         ds = xr.Dataset(coords=coords)
 
-        dims = ["leadtime", "k"]
-        ds["skill"] = (dims, skill_k)
-        ds["spread"] = (dims, spread_k)
+        dims = ["time", "leadtime", "k"]
+        ds["error_variance"] = (dims, error_variance)
+        ds["spread_variance"] = (dims, spread_variance)
+        ds["spectrum_forecast"] = (dims + ["ensemble_member"], spectrum_forecast)
+        ds["spectrum_target"] = (dims, spectrum_observation)
 
         datestr = datetime.datetime.now(datetime.timezone.utc).strftime(
             "%Y-%m-%d %H:%M:%S +00:00"
         )
         ds.attrs["history"] = f"{datestr} Created by bris-inference"
         ds.attrs["Conventions"] = "CF-1.6"
+        ds.attrs["standard_name"] = cf.get_metadata(self.variable)["cfname"]
 
         utils.create_directory(self.filename)
         ds.to_netcdf(self.filename, mode="w", engine="netcdf4")
@@ -197,7 +262,7 @@ class SpectralSkillSpread():
         k_edges = np.linspace(0.0, k_max, n_bins + 1)
         k_bins = 0.5 * (k_edges[1:] + k_edges[:-1])
         return k_edges, k_bins, k
-    
+
     @cached_property
     def get_latlons(self) -> tuple:
         return self.pm.lats, self.pm.lons

--- a/bris/outputs/spectral.py
+++ b/bris/outputs/spectral.py
@@ -1,10 +1,14 @@
 import numpy as np
-
+from functools import cached_property
 from abc import abstractmethod
+from scipy.fft import dctn
 
+from bris import projections
+from bris.conventions import cf
 from bris.outputs import Output
 from bris.predict_metadata import PredictMetadata
 from bris.outputs.intermediate import IntermediateSpatial
+from anemoi.datasets import open_dataset
 
 
 class SpectralSkillSpread():
@@ -18,6 +22,7 @@ class SpectralSkillSpread():
         variable: str,
         obs_dataset: str,
         remove_intermediate: bool = True,
+        n_bins: int = None,
     ) -> None:
         extra_variables = []
         if variable not in predict_metadata.variables:
@@ -34,10 +39,18 @@ class SpectralSkillSpread():
             extra_variables=extra_variables,
         )
         self.remove_intermediate = remove_intermediate
-        
+        self.n_bins = n_bins
+        assert self.pm.is_gridded, "SpectralSkillSpread only works for gridded data"
+        self.obs_dataset = open_dataset(obs_dataset)
 
-    @abstractmethod
-    def transform(data: np.ndarray): ...
+    def get_observations_for_valid_times(self, frt: np.datetime64) -> np.ndarray:
+        valid_times = [frts + np.timedelta64(lt, "s") for lt in self.pm.leadtimes]
+        time_indices = [np.argmin(np.abs(self.obs_dataset.dates - t)) for t in valid_times]
+        var_index = self.obs_dataset.name_to_index(self.variable)
+        #Debug
+        print("valid_times: ", valid_times)
+        print("time_indices: ", time_indeices)
+        return self.obs_dataset[time_indices, var_index, 0, ...]
 
     def _add_forecast(
         self, times: list, ensemble_member: int, pred: np.ndarray
@@ -53,13 +66,122 @@ class SpectralSkillSpread():
 
     def finalize(self) -> None:
         """ Calculate skill spread and write to file"""
+        nx, ny = self.pm.field_shape
+
+        _skill = np.zeros((self.pm.num_leadtimes, nx, ny))
+        spread = np.zeros((self.pm.num_leadtimes, nx, ny))
+        
         frts = self.intermediate.get_forecast_reference_times()
+        N_t = len(frts)
+        N = self.pm.num_members
+
         for frt in frts:
             pred = np.zeros((self.pm.num_leadtimes, self.pm.num_points, self.pm.num_members))
             for member in range(self.pm.num_members):
                 pred[..., member] = self.intermediate.get_forecast(frt, member)
             
-            pred_transformed = self.transform(pred)
+            # Calculate skill
+            obs = self.get_observations_for_valid_times(frt) #(time, latlon)
+            
+            obs = obs.reshape(obs.shape[0], nx, ny) #(lt, x, y)
+            pred = pred.reshape(pred.shape[0], nx, ny, pred.shape[2]) #(lt, x, y, ens)
 
+            obs_k = dctn(obs, axes=(1,2), type=2, norm="ortho") #time, kx, ky
+            pred_k = dctn(pred, axes=(1,2), type=2, norm="ortho") #time, kx, ky, ens
 
-        
+            ens_mean = pred_k.mean(axis=3) / N
+            
+            _skill += (ens_mean - obs_k)**2 / N_t
+            spread += np.sqrt( ( (pred_k - ens_mean[..., None])**2).sum(axis=3) / (N-1) ) / N_t
+
+        skill = np.sqrt(_skill)
+
+        k_edges, k_bins, k = self.get_bins()
+        n_bins = k_bins.shape[0]
+        digitized = np.digitize(k.flatten(), k_edges)
+
+        skill_k = np.full((self.pm.num_leadtimes, n_bins), np.nan)
+        spread_k = np.full((self.pm.num_leadtimes, n_bins), np.nan)
+
+        for lt in range(leadtimes):
+            skill_k[lt] = np.array(
+                [
+                    skill[lt].flatten()[digitized == i].mean() if np.any(digitized == i) else 0 
+                    for i in range(1, n_bins + 1)
+                ]
+            )
+            spread_k[lt] = np.array(
+                [
+                    skill[lt].flatten()[digitized == i].mean() if np.any(digitized == i) else 0 
+                    for i in range(1, n_bins + 1)
+                ]
+            )
+
+        self.write(spread_k, skill_k)
+        if self.remove_intermediate:
+            self.intermediate.cleanup()
+
+    def write(self, spread_k: np.ndarray, skill_k: np.ndarray, k_bin: np.ndarray) -> None:
+        """Writes output to file"""
+        coords = {}
+
+        coords["leadtime"] = (
+            ["leadtime"],
+            self.intermediate.pm.leadtimes.astype(np.float32) / 3600,
+            {"units": "hour"},
+        )
+        coords["k"] = (
+            ["k"],
+            k_bin,
+            cf.get_attributes("k")
+        )
+
+        ds = xr.Dataset(coords=coords)
+
+        dims = ["leadtime", "k"]
+        ds["skill"] = (dims, skill_k)
+        ds["spread"] = (dims, spread_k)
+
+        datestr = datetime.datetime.now(datetime.timezone.utc).strftime(
+            "%Y-%m-%d %H:%M:%S +00:00"
+        )
+        self.ds.attrs["history"] = f"{datestr} Created by bris-inference"
+        self.ds.attrs["Convensions"] = "CF-1.6"
+
+        utils.create_directory(self.filename)
+        ds.to_netcdf(self.filename, mode="w", engine="netcdf4")
+
+    @cached_property
+    def get_bins(self):
+        """Calculates wavenumbers, bins and bin-edges used in the CDT calculation."""
+        nx, ny = self.pm.field_shape
+        lats, lons = self.get_latlons
+        x, y = projections.get_xy(
+            lats.reshape(nx, ny), lons.reshape(nx, ny), self.proj4_str
+        )
+
+        dx = np.mean(np.diff(x))
+        dy = np.mean(np.diff(y))
+        assert np.allclose(np.diff(x), dx, atol=1.0), (
+            "Non-uniform grid spacing in x-direction"
+        )
+        assert np.allclose(np.diff(y), dy, atol=1.0), (
+            "Non-uniform grid spacing in y-direction"
+        )
+
+        kx = np.pi * np.arange(nx) / (nx * dx)
+        ky = np.pi * np.arange(ny) / (ny * dy)
+
+        KX, KY = np.meshgrid(kx, ky, indexing="ij")
+        k = np.sqrt(KX**2 + KY**2)
+        k_max = k.max()
+
+        n_bins = self.n_bins if self.n_bins is not None else min(nx, ny) // 2
+
+        k_edges = np.linspace(0.0, k_max, n_bins + 1)
+        k_bins = 0.5 * (k_edges[1:] + k_edges[:-1])
+        return k_edges, k_bins, k
+    
+    @cached_property
+    def get_latlons(self) -> tuple:
+        return self.pm.lats, self.pm.lons

--- a/bris/outputs/spectral.py
+++ b/bris/outputs/spectral.py
@@ -2,8 +2,10 @@ import numpy as np
 from functools import cached_property
 from abc import abstractmethod
 from scipy.fft import dctn
+import xarray as xr
+import datetime
 
-from bris import projections
+from bris import projections, utils
 from bris.conventions import cf
 from bris.outputs import Output
 from bris.predict_metadata import PredictMetadata
@@ -23,12 +25,18 @@ class SpectralSkillSpread():
         obs_dataset: str,
         remove_intermediate: bool = True,
         n_bins: int = None,
+        proj4_str: str | None = None,
+        domain_name: str | None = None,
     ) -> None:
         extra_variables = []
         if variable not in predict_metadata.variables:
             extra_variables += [variable]
         
         self.pm = predict_metadata
+        if domain_name is not None:
+            self.proj4_str = projections.get_proj4_str(domain_name)
+        else:
+            self.proj4_str = proj4_str
         self.variable = variable
         self.filename = filename
         shape = (predict_metadata.num_points)
@@ -44,15 +52,22 @@ class SpectralSkillSpread():
         self.obs_dataset = open_dataset(obs_dataset)
 
     def get_observations_for_valid_times(self, frt: np.datetime64) -> np.ndarray:
-        valid_times = [frts + np.timedelta64(lt, "s") for lt in self.pm.leadtimes]
+        valid_times = [frt + np.timedelta64(lt, "s") for lt in self.pm.leadtimes]
         time_indices = [np.argmin(np.abs(self.obs_dataset.dates - t)) for t in valid_times]
-        var_index = self.obs_dataset.name_to_index(self.variable)
+        if self.variable == "ws":
+            u_index = self.obs_dataset.name_to_index["10u"]
+            v_index = self.obs_dataset.name_to_index["10v"]
+            u = self.obs_dataset[time_indices, u_index, 0, ...]
+            v = self.obs_dataset[time_indices, v_index, 0, ...]
+            return np.sqrt(u**2 + v**2)
+
+        var_index = self.obs_dataset.name_to_index[self.variable]
         #Debug
         print("valid_times: ", valid_times)
-        print("time_indices: ", time_indeices)
+        print("time_indices: ", time_indices)
         return self.obs_dataset[time_indices, var_index, 0, ...]
 
-    def _add_forecast(
+    def add_forecast(
         self, times: list, ensemble_member: int, pred: np.ndarray
     ) -> None:
         if self.variable == "ws":
@@ -78,7 +93,7 @@ class SpectralSkillSpread():
         for frt in frts:
             pred = np.zeros((self.pm.num_leadtimes, self.pm.num_points, self.pm.num_members))
             for member in range(self.pm.num_members):
-                pred[..., member] = self.intermediate.get_forecast(frt, member)
+                pred[..., member] = self.intermediate.get_forecast(frt, member).squeeze(-1)
             
             # Calculate skill
             obs = self.get_observations_for_valid_times(frt) #(time, latlon)
@@ -96,14 +111,14 @@ class SpectralSkillSpread():
 
         skill = np.sqrt(_skill)
 
-        k_edges, k_bins, k = self.get_bins()
+        k_edges, k_bins, k = self.get_bins
         n_bins = k_bins.shape[0]
         digitized = np.digitize(k.flatten(), k_edges)
 
         skill_k = np.full((self.pm.num_leadtimes, n_bins), np.nan)
         spread_k = np.full((self.pm.num_leadtimes, n_bins), np.nan)
 
-        for lt in range(leadtimes):
+        for lt in range(self.pm.num_leadtimes):
             skill_k[lt] = np.array(
                 [
                     skill[lt].flatten()[digitized == i].mean() if np.any(digitized == i) else 0 
@@ -112,12 +127,12 @@ class SpectralSkillSpread():
             )
             spread_k[lt] = np.array(
                 [
-                    skill[lt].flatten()[digitized == i].mean() if np.any(digitized == i) else 0 
+                    spread[lt].flatten()[digitized == i].mean() if np.any(digitized == i) else 0 
                     for i in range(1, n_bins + 1)
                 ]
             )
 
-        self.write(spread_k, skill_k)
+        self.write(spread_k, skill_k, k_bins)
         if self.remove_intermediate:
             self.intermediate.cleanup()
 
@@ -135,6 +150,7 @@ class SpectralSkillSpread():
             k_bin,
             cf.get_attributes("k")
         )
+        #TODO: convert from k to wavelength and add wavelength as a coordinate
 
         ds = xr.Dataset(coords=coords)
 
@@ -145,8 +161,8 @@ class SpectralSkillSpread():
         datestr = datetime.datetime.now(datetime.timezone.utc).strftime(
             "%Y-%m-%d %H:%M:%S +00:00"
         )
-        self.ds.attrs["history"] = f"{datestr} Created by bris-inference"
-        self.ds.attrs["Convensions"] = "CF-1.6"
+        ds.attrs["history"] = f"{datestr} Created by bris-inference"
+        ds.attrs["Conventions"] = "CF-1.6"
 
         utils.create_directory(self.filename)
         ds.to_netcdf(self.filename, mode="w", engine="netcdf4")

--- a/bris/outputs/spectral.py
+++ b/bris/outputs/spectral.py
@@ -1,0 +1,65 @@
+import numpy as np
+
+from abc import abstractmethod
+
+from bris.outputs import Output
+from bris.predict_metadata import PredictMetadata
+from bris.outputs.intermediate import IntermediateSpatial
+
+
+class SpectralSkillSpread():
+    """Calculates skill and spread on different length scales using the Discrete Cosine Transform (DCT)"""
+
+    def __init__(
+        self,
+        predict_metadata: PredictMetadata,
+        workdir: str,
+        filename: str,
+        variable: str,
+        obs_dataset: str,
+        remove_intermediate: bool = True,
+    ) -> None:
+        extra_variables = []
+        if variable not in predict_metadata.variables:
+            extra_variables += [variable]
+        
+        self.pm = predict_metadata
+        self.variable = variable
+        self.filename = filename
+        shape = (predict_metadata.num_points)
+        self.intermediate = IntermediateSpatial(
+            predict_metadata=predict_metadata,
+            workdir=workdir,
+            metric_shape = shape,
+            extra_variables=extra_variables,
+        )
+        self.remove_intermediate = remove_intermediate
+        
+
+    @abstractmethod
+    def transform(data: np.ndarray): ...
+
+    def _add_forecast(
+        self, times: list, ensemble_member: int, pred: np.ndarray
+    ) -> None:
+        if self.variable == "ws":
+            Ix = self.pm.variables.index("10u")
+            Iy = self.pm.variables.index("10v")
+            pred = np.sqrt(pred[..., [Ix]] ** 2 + pred[..., [Iy]] ** 2)
+        else:
+            pred = pred[..., [self.pm.variables.index(self.variable)]]
+        
+        self.intermediate._add_forecast(times, ensemble_member, pred)
+
+    def finalize(self) -> None:
+        """ Calculate skill spread and write to file"""
+        frts = self.intermediate.get_forecast_reference_times()
+        for frt in frts:
+            pred = np.zeros((self.pm.num_leadtimes, self.pm.num_points, self.pm.num_members))
+            for member in range(self.pm.num_members):
+                pred[..., member] = self.intermediate.get_forecast(frt, member)
+            
+            pred_transformed = self.transform(pred)
+
+
+        

--- a/bris/schema/schema.json
+++ b/bris/schema/schema.json
@@ -183,11 +183,11 @@
             "required": ["powerspectrum_gridded"]
         },
 
-        "SpectralSpreadSkill": {
-            "description": "Spectral spread-skill output file",
+        "SpectralGridded": {
+            "description": "Spectral gridded output file",
             "type": "object",
             "properties": {
-                "spectral_spread_skill": {
+                "spectral_gridded": {
                     "type": "object",
                     "properties": {
                         "filename": {
@@ -195,7 +195,7 @@
                             "type": "string"
                         },
                         "variable": {
-                            "description": "What anemoi variable to compute spectral spread-skill for? Can include variables that can be diagnosed from other variables (e.g. 10si from 10u and 10v)",
+                            "description": "What anemoi variable to compute spectral gridded output for? Can include variables that can be diagnosed from other variables (e.g. 10si from 10u and 10v)",
                             "type": "string"
                         },
                         "obs_dataset": {
@@ -214,7 +214,7 @@
                     "required": ["filename", "variable", "obs_dataset"]
                 }
             },
-            "required": ["spectral_spread_skill"]
+            "required": ["spectral_gridded"]
         },
 
         "VerifSource": {
@@ -378,7 +378,7 @@
                                 {"$ref": "#/$defs/GribOutput"},
                                 {"$ref": "#/$defs/SHPowerSpectrumOutput"},
                                 {"$ref": "#/$defs/DCTPowerSpectrum"},
-                                {"$ref": "#/$defs/SpectralSpreadSkill"}
+                                {"$ref": "#/$defs/SpectralGridded"}
                             ]
                         }
                     }

--- a/bris/schema/schema.json
+++ b/bris/schema/schema.json
@@ -183,6 +183,40 @@
             "required": ["powerspectrum_gridded"]
         },
 
+        "SpectralSpreadSkill": {
+            "description": "Spectral spread-skill output file",
+            "type": "object",
+            "properties": {
+                "spectral_spread_skill": {
+                    "type": "object",
+                    "properties": {
+                        "filename": {
+                            "description": "Where to write the output file. Use %R for run_name",
+                            "type": "string"
+                        },
+                        "variable": {
+                            "description": "What anemoi variable to compute spectral spread-skill for? Can include variables that can be diagnosed from other variables (e.g. 10si from 10u and 10v)",
+                            "type": "string"
+                        },
+                        "obs_dataset": {
+                            "description": "Observations dataset to use for computing spectral spread-skill, in anemoi datasets open_dataset recipe format",
+                            "type": "object"
+                        },
+                        "proj4_str": {
+                            "description": "Assume this projection string when computing x/y coordinates",
+                            "type": "string"
+                        },
+                        "domain_name": {
+                            "description": "Retrieve projection from this predefined domain name (e.g. meps)",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["filename", "variable", "obs_dataset"]
+                }
+            },
+            "required": ["spectral_spread_skill"]
+        },
+
         "VerifSource": {
             "description": "Observations stored in a Netcdf verif file",
             "type": "object",
@@ -343,7 +377,8 @@
                                 {"$ref": "#/$defs/VerifOutput"},
                                 {"$ref": "#/$defs/GribOutput"},
                                 {"$ref": "#/$defs/SHPowerSpectrumOutput"},
-                                {"$ref": "#/$defs/DCTPowerSpectrum"}
+                                {"$ref": "#/$defs/DCTPowerSpectrum"},
+                                {"$ref": "#/$defs/SpectralSpreadSkill"}
                             ]
                         }
                     }


### PR DESCRIPTION
Adds a new output spectral_gridded (currently not implemented for global unstructured fields). This computes some quantities in spectral space and stores them in a verif-style output nc file
- forecast spectral power (time, leadtime, k, ens_member)
- target spectral power (time, leadtime, k)
- error variance (time, leadtime, k)
- spread variance (time, leadtime, k)
The latter two can be used to calculate spread / skill as a function of wavelength for some time period