### PR TITLE
Add ensemble-reduced outputs and an ensemble_statistics output

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ the [Anemoi framework](https://github.com/ecmwf/anemoi-training).
 - Multi encoder/decoder
 - Time interpolation
 - Ensembles
+- Ensemble statistics (mean, spread, min, max) computed batch by batch without storing individual members (`ensemble_statistics` output)
 
 ## Documentation
 

--- a/bris/ddp_strategy.py
+++ b/bris/ddp_strategy.py
@@ -174,6 +174,27 @@ class DDPGroupStrategy(DDPStrategy):
             self.ens_comm_group_size,
         )
 
+        # Set up groups of the output-writing ranks (rank 0 of each model group) within each
+        # ensemble group. These are used by the writer to reduce quantities across the ensemble
+        # members that run in parallel.
+        ens_output_group_ranks = [
+            ranks[:: self.model_comm_group_size] for ranks in ens_comm_group_ranks
+        ]
+        ens_output_groups = [
+            torch.distributed.new_group(x) for x in ens_output_group_ranks
+        ]
+        if hasattr(self.model, "set_ens_output_comm_group"):
+            self.model.set_ens_output_comm_group(ens_output_groups[ens_comm_group_id])
+        LOGGER.debug(
+            "Rank %d ens_comm_group_id: %d ens_comm_group: %s ens_comm_group_rank: %d member_id: %d ens_output_group: %s",
+            self.global_rank,
+            ens_comm_group_id,
+            str(ens_comm_group_ranks[ens_comm_group_id]),
+            ens_comm_group_rank,
+            member_id,
+            str(ens_output_group_ranks[ens_comm_group_id]),
+        )
+
         # register hooks for correct gradient reduction
         self.register_parameter_hooks()
 

--- a/bris/model/basepredictor.py
+++ b/bris/model/basepredictor.py
@@ -60,6 +60,10 @@ class BasePredictor(pl.LightningModule):
         super().__init__(*args, **kwargs)
         self.num_members_in_parallel = num_members_in_parallel
 
+        # Process group of the ranks that write output (rank 0 of each model group) within an
+        # ensemble group. Used to reduce output quantities across ensemble members.
+        self.ens_output_comm_group = None
+
         if check_anemoi_training(checkpoints["forecaster"].metadata):
             self.legacy = False
 
@@ -134,6 +138,9 @@ class BasePredictor(pl.LightningModule):
             self.ens_comm_num_groups = ens_comm_num_groups
             self.ens_comm_group_size = ens_comm_group_size
             self.member_id = member_id
+
+    def set_ens_output_comm_group(self, ens_output_comm_group: ProcessGroup) -> None:
+        self.ens_output_comm_group = ens_output_comm_group
 
     def set_reader_groups(
         self,

--- a/bris/outputs/__init__.py
+++ b/bris/outputs/__init__.py
@@ -40,6 +40,9 @@ def instantiate(name: str, predict_metadata: PredictMetadata, workdir: str, init
     if name == "powerspectrum_gridded":
         return DCTPowerSpectrum(predict_metadata, workdir, **init_args)
 
+    if name == "ensemble_statistics":
+        return EnsembleStatistics(predict_metadata, workdir, **init_args)
+
     raise ValueError(f"Invalid output: {name}")
 
 
@@ -48,7 +51,7 @@ def get_required_variables(name, init_args):
     provided
     """
 
-    if name == "netcdf":
+    if name in ["netcdf", "ensemble_statistics"]:
         if "variables" in init_args:
             variables = list(init_args["variables"])
             if "extra_variables" in init_args:
@@ -83,7 +86,25 @@ def get_required_variables(name, init_args):
 
 
 class Output:
-    """This class writes output for a specific part of the domain"""
+    """This class writes output for a specific part of the domain
+
+    Outputs receive one ensemble member at a time through add_forecast, since members are run
+    data-parallel (on different ranks) and/or in sequence. Outputs that only need quantities that
+    are summed/averaged across the ensemble (e.g. ensemble mean and spread) can instead opt in to
+    the ensemble-reduction protocol by setting reduce_across_members = True and implementing
+    _member_contribution and add_reduced_forecast. The writer then reduces the contributions from
+    all members that run in parallel across ranks, and only the ensemble-root rank receives the
+    reduced result. Members that run in sequence arrive as separate add_reduced_forecast calls
+    for the same forecast reference time and must be accumulated by the output (see
+    bris.outputs.intermediate.IntermediateEnsembleAccumulator).
+    """
+
+    # Set to True in subclasses that implement the ensemble-reduction protocol
+    reduce_across_members: bool = False
+
+    # For ensemble-reduced outputs: name of each contribution -> reduction operation
+    # ("sum", "min" or "max"). The names must match the keys returned by _member_contribution.
+    ensemble_reductions: dict[str, str] = {}
 
     def __init__(
         self, predict_metadata: PredictMetadata, extra_variables: list | None = None
@@ -112,6 +133,60 @@ class Output:
             ensemble_member: Which ensemble member is this?
             pred: 3D numpy array with dimensions (leadtime, location, variable)
         """
+        pred = self._prepare_pred(ensemble_member, pred)
+
+        t1 = time.perf_counter()
+        self._add_forecast(times, ensemble_member, pred)
+        LOGGER.debug(
+            f"outputs.add_forecast called _add_forecast in {time.perf_counter() - t1:.1f}s"
+        )
+
+    def member_contribution(
+        self, times: list, ensemble_member: int, pred: np.ndarray
+    ) -> dict[str, np.ndarray]:
+        """Computes this member's contribution to the ensemble reductions (see
+        ensemble_reductions). Only used by outputs with reduce_across_members = True.
+
+        Args:
+            times: List of np.datetime64 objects
+            ensemble_member: Which ensemble member is this?
+            pred: 3D numpy array with dimensions (leadtime, location, variable)
+
+        Returns:
+            dict with one numpy array for each key in ensemble_reductions
+        """
+        assert self.reduce_across_members
+        pred = self._prepare_pred(ensemble_member, pred)
+        contributions = self._member_contribution(times, ensemble_member, pred)
+        assert set(contributions.keys()) == set(self.ensemble_reductions.keys()), (
+            sorted(contributions.keys()),
+            sorted(self.ensemble_reductions.keys()),
+        )
+        return contributions
+
+    def _member_contribution(
+        self, times: list, ensemble_member: int, pred: np.ndarray
+    ) -> dict[str, np.ndarray]:
+        """Subclasses with reduce_across_members = True should implement this"""
+        raise NotImplementedError()
+
+    def add_reduced_forecast(
+        self, times: list, contributions: dict[str, np.ndarray], num_members: int
+    ) -> None:
+        """Registers contributions that have already been reduced across num_members ensemble
+        members. Can be called several times for the same forecast reference time (when members
+        run in sequence), in which case the output must accumulate the contributions.
+
+        Args:
+            times: List of np.datetime64 objects
+            contributions: dict with one numpy array for each key in ensemble_reductions
+            num_members: How many ensemble members have been reduced into contributions
+        """
+        raise NotImplementedError()
+
+    def _prepare_pred(self, ensemble_member: int, pred: np.ndarray) -> np.ndarray:
+        """Appends extra variables to the prediction and checks that its shape matches the
+        predict metadata."""
 
         # Append extra variables to prediction
         for name in self.extra_variables:
@@ -146,11 +221,7 @@ class Output:
         assert ensemble_member >= 0
         assert ensemble_member < self.pm.num_members
 
-        t1 = time.perf_counter()
-        self._add_forecast(times, ensemble_member, pred)
-        LOGGER.debug(
-            f"outputs.add_forecast called _add_forecast in {time.perf_counter() - t1:.1f}s"
-        )
+        return pred
 
     @abstractmethod
     def _add_forecast(self, times: list, ensemble_member: int, pred: np.ndarray):
@@ -194,6 +265,7 @@ class Output:
         return pred
 
 
+from .ensemble_statistics import EnsembleStatistics
 from .grib import Grib
 from .intermediate import Intermediate
 from .netcdf import Netcdf

--- a/bris/outputs/ensemble_statistics.py
+++ b/bris/outputs/ensemble_statistics.py
@@ -1,0 +1,272 @@
+import time as pytime
+
+import numpy as np
+
+import bris.units
+from bris import utils
+from bris.outputs import Output
+from bris.outputs.intermediate import IntermediateEnsembleAccumulator
+from bris.outputs.netcdf import Netcdf
+from bris.predict_metadata import PredictMetadata
+
+
+class EnsembleStatistics(Output):
+    """Writes statistics across the ensemble (mean, standard deviation, min, max) to NetCDF,
+    without ever storing the individual ensemble members.
+
+    For each batch (forecast reference time), every member contributes its prediction, its
+    squared prediction, and its min/max. These are reduced across the members that run in
+    parallel by the writer, and accumulated on disk (see IntermediateEnsembleAccumulator) across
+    members that run in sequence. On finalize, the statistics are computed from the accumulated
+    quantities and written using the same conventions as the netcdf output.
+
+    Compared to the netcdf output with an ensemble, the intermediate storage is independent of
+    the number of members: at most 4 arrays (each the size of one member) per forecast reference
+    time, and finalize never needs to hold the full ensemble in memory.
+
+    Example config:
+        - ensemble_statistics:
+            filename_pattern: /path/ens_{statistic}_%Y%m%dT%HZ.nc
+            variables: [2t, 10u, 10v]
+            extra_variables: [ws]
+            statistics: [mean, std]
+            domain_name: meps
+    """
+
+    reduce_across_members = True
+    ensemble_reductions = {"sum": "sum", "sum_sq": "sum", "min": "min", "max": "max"}
+    valid_statistics = ("mean", "std", "min", "max")
+    statistic_token = "{statistic}"
+
+    # CF cell_methods for each statistic
+    cell_methods = {
+        "mean": "realization: mean",
+        "std": "realization: standard_deviation",
+        "min": "realization: minimum",
+        "max": "realization: maximum",
+    }
+
+    def __init__(
+        self,
+        predict_metadata: PredictMetadata,
+        workdir: str,
+        filename_pattern: str,
+        variables: list | None = None,
+        extra_variables: list | None = None,
+        statistics: list | None = None,
+        ddof: int = 0,
+        interp_res=None,
+        latrange=None,
+        lonrange=None,
+        proj4_str=None,
+        domain_name=None,
+        mask_file: str = "",
+        mask_field=None,
+        global_attributes=None,
+        remove_intermediate: bool = True,
+        compression: bool = False,
+    ):
+        """
+        Args:
+            filename_pattern: Save statistics to this filename after time tokens are expanded.
+                Must contain the token {statistic} (replaced by e.g. "mean") when more than one
+                statistic is requested.
+            variables: If None, compute statistics for all variables
+            extra_variables: Derive these extra variables (e.g. ws) before computing statistics
+            statistics: Which of "mean", "std", "min", "max" to write. Default: mean and std
+            ddof: Delta degrees of freedom used for std (0: population, 1: sample)
+            interp_res, latrange, lonrange, proj4_str, domain_name, mask_file, mask_field,
+                global_attributes, compression: See the netcdf output
+        """
+        super().__init__(predict_metadata, extra_variables)
+
+        if statistics is None:
+            statistics = ["mean", "std"]
+        statistics = list(statistics)
+        if len(statistics) == 0:
+            raise ValueError("At least one statistic must be requested")
+        for statistic in statistics:
+            if statistic not in self.valid_statistics:
+                raise ValueError(
+                    f"Invalid statistic '{statistic}'. Must be one of {self.valid_statistics}"
+                )
+        if len(statistics) > 1 and self.statistic_token not in filename_pattern:
+            raise ValueError(
+                f"filename_pattern must contain {self.statistic_token} when writing more than one statistic"
+            )
+        if ddof < 0:
+            raise ValueError(f"ddof must be non-negative, got {ddof}")
+
+        self.statistics = statistics
+        self.ddof = ddof
+        self.filename_pattern = filename_pattern
+        self.remove_intermediate = remove_intermediate
+
+        # Only accumulate the variables that will be written
+        if variables is None:
+            self.extract_variables = list(self.pm.variables)
+        else:
+            self.extract_variables = list(variables)
+            for name in self.extra_variables:
+                if name not in self.extract_variables:
+                    self.extract_variables += [name]
+        for variable in self.extract_variables:
+            if variable not in self.pm.variables:
+                raise ValueError(
+                    f"Variable '{variable}' is not available in the predictions ({self.pm.variables})"
+                )
+        self.variable_indices = [
+            self.pm.variables.index(v) for v in self.extract_variables
+        ]
+
+        self.intermediate = IntermediateEnsembleAccumulator(
+            workdir, self.ensemble_reductions
+        )
+
+        # The netcdf writers see the statistics as a deterministic (single member) forecast
+        # containing only the extracted variables
+        writer_pm = PredictMetadata(
+            self.extract_variables,
+            self.pm.lats,
+            self.pm.lons,
+            self.pm.altitudes,
+            self.pm.leadtimes,
+            1,
+            self.pm.field_shape,
+        )
+        self.writers = {}
+        for statistic in self.statistics:
+            pattern = filename_pattern.replace(self.statistic_token, statistic)
+            self.writers[statistic] = _StatisticNetcdf(
+                statistic,
+                writer_pm,
+                workdir,
+                pattern,
+                variables=self.extract_variables,
+                interp_res=interp_res,
+                latrange=latrange,
+                lonrange=lonrange,
+                proj4_str=proj4_str,
+                domain_name=domain_name,
+                mask_file=mask_file,
+                mask_field=mask_field,
+                global_attributes=global_attributes,
+                compression=compression,
+            )
+
+    def _member_contribution(
+        self, times: list, ensemble_member: int, pred: np.ndarray
+    ) -> dict[str, np.ndarray]:
+        # Accumulate in double precision, since sum_sq - sum^2/n loses precision in float32 for
+        # variables with a large mean (e.g. temperature in K)
+        curr = pred[..., self.variable_indices].astype(np.float64)
+        return {
+            "sum": curr,
+            "sum_sq": curr**2,
+            "min": curr,
+            "max": curr,
+        }
+
+    def _add_forecast(
+        self, times: list, ensemble_member: int, pred: np.ndarray
+    ) -> None:
+        """Fallback for callers that do not reduce across members (e.g. when members run in
+        sequence on a single process): accumulate this member directly"""
+        contributions = self._member_contribution(times, ensemble_member, pred)
+        self.add_reduced_forecast(times, contributions, 1)
+
+    def add_reduced_forecast(
+        self, times: list, contributions: dict[str, np.ndarray], num_members: int
+    ) -> None:
+        t0 = pytime.perf_counter()
+        self.intermediate.accumulate(times[0], contributions, num_members)
+        utils.LOGGER.debug(
+            f"EnsembleStatistics.add_reduced_forecast for {times[0]} ({num_members} members) in {pytime.perf_counter() - t0:.1f}s"
+        )
+
+    def compute_statistics(
+        self, accumulated: dict[str, np.ndarray], num_members: int
+    ) -> dict[str, np.ndarray]:
+        """Computes the requested statistics from the accumulated quantities
+
+        Args:
+            accumulated: dict with "sum", "sum_sq", "min", "max", each with dimensions
+                (leadtime, location, variable)
+            num_members: Number of members that have been accumulated
+
+        Returns:
+            dict statistic -> array with dimensions (leadtime, location, variable)
+        """
+        assert num_members > 0
+        ret = {}
+        mean = accumulated["sum"] / num_members
+        for statistic in self.statistics:
+            if statistic == "mean":
+                ret[statistic] = mean
+            elif statistic == "std":
+                if num_members - self.ddof <= 0:
+                    ret[statistic] = np.full(mean.shape, np.nan)
+                else:
+                    # Sum of squared deviations from the mean
+                    ss = accumulated["sum_sq"] - num_members * mean**2
+                    ss = np.maximum(ss, 0)  # Guard against round-off
+                    ret[statistic] = np.sqrt(ss / (num_members - self.ddof))
+            elif statistic in ["min", "max"]:
+                ret[statistic] = accumulated[statistic]
+            else:
+                raise ValueError(f"Unknown statistic '{statistic}'")
+        return ret
+
+    def finalize(self) -> None:
+        t0 = pytime.perf_counter()
+        frts = self.intermediate.get_forecast_reference_times()
+        if len(frts) == 0:
+            utils.LOGGER.warning(
+                "EnsembleStatistics.finalize: No forecasts have been accumulated"
+            )
+
+        for frt in frts:
+            num_members = self.intermediate.get_num_members(frt)
+            if num_members != self.pm.num_members:
+                utils.LOGGER.warning(
+                    f"EnsembleStatistics: {num_members} members accumulated for {frt}, expected {self.pm.num_members}"
+                )
+            accumulated = self.intermediate.get(frt)
+            statistics = self.compute_statistics(accumulated, num_members)
+
+            frt_ut = int(utils.datetime_to_unixtime(frt))
+            lead_times = [frt + lt for lt in self.pm.leadtimes]
+            for statistic, values in statistics.items():
+                writer = self.writers[statistic]
+                filename = writer.get_filename(frt_ut)
+                # Netcdf.write expects (leadtime, location, variable, member)
+                writer.write(filename, lead_times, values.astype(np.float32)[..., None])
+
+        if self.remove_intermediate:
+            self.intermediate.cleanup()
+        utils.LOGGER.debug(
+            f"EnsembleStatistics.finalize: {pytime.perf_counter() - t0:.1f}s"
+        )
+
+
+class _StatisticNetcdf(Netcdf):
+    """Netcdf writer for a single ensemble statistic. Standard deviations are a difference
+    quantity, so only the scale part of unit conversions applies to them (e.g. K -> C must not
+    subtract 273.15)."""
+
+    def __init__(self, statistic: str, *args, **kwargs):
+        self.statistic = statistic
+        super().__init__(*args, **kwargs)
+
+    def _convert_units(
+        self, ar: np.ndarray, from_units: str, to_units: str
+    ) -> np.ndarray:
+        if self.statistic == "std":
+            zero, one = bris.units.convert(np.array([0.0, 1.0]), from_units, to_units)[
+                0
+            ]
+            return ar * (one - zero)
+        return super()._convert_units(ar, from_units, to_units)
+
+    def _extra_variable_attrs(self) -> dict:
+        return {"cell_methods": EnsembleStatistics.cell_methods[self.statistic]}

--- a/bris/outputs/intermediate.py
+++ b/bris/outputs/intermediate.py
@@ -154,3 +154,144 @@ class IntermediateSpatial(Intermediate):
             pred = np.load(filename) if os.path.exists(filename) else None
 
         return pred
+
+
+class IntermediateEnsembleAccumulator:
+    """Stores quantities that have been reduced across ensemble members (e.g. ensemble sums),
+    instead of one forecast per member. One directory is used per forecast reference time, holding
+    one .npy file per accumulated quantity plus a member count.
+
+    Contributions for the same forecast reference time can be added several times (e.g. when
+    members run in sequence, or when several groups of members are reduced separately). They are
+    combined with the reduction operation registered for each quantity ("sum", "min" or "max").
+    All accumulation happens through read-modify-write of the files, so calls for the same
+    forecast reference time must come from a single process and must not overlap in time. The
+    writer guarantees this, since only the ensemble-root rank receives reduced contributions and
+    it waits for the previous batch to be stored before starting on the next.
+    """
+
+    valid_reductions = ("sum", "min", "max")
+    count_name = "num_members"
+
+    def __init__(self, workdir: str, reductions: dict[str, str]) -> None:
+        """
+        Args:
+            workdir: Directory to store files in
+            reductions: name -> reduction operation for each quantity to accumulate
+        """
+        for name, op in reductions.items():
+            if op not in self.valid_reductions:
+                raise ValueError(
+                    f"Invalid reduction '{op}' for '{name}'. Must be one of {self.valid_reductions}"
+                )
+            if name == self.count_name or not name.isidentifier():
+                raise ValueError(f"Invalid accumulator name '{name}'")
+        self.workdir = workdir
+        self.reductions = dict(reductions)
+
+    def accumulate(
+        self,
+        forecast_reference_time,
+        contributions: dict[str, np.ndarray],
+        num_members: int,
+    ) -> None:
+        """Combines contributions (already reduced across num_members members) with what has
+        been stored for this forecast reference time"""
+        t0 = time.perf_counter()
+        assert set(contributions.keys()) == set(self.reductions.keys()), (
+            sorted(contributions.keys()),
+            sorted(self.reductions.keys()),
+        )
+        assert num_members > 0
+
+        directory = self.get_directory(forecast_reference_time)
+        os.makedirs(directory, exist_ok=True)
+
+        for name, op in self.reductions.items():
+            filename = self.get_filename(forecast_reference_time, name)
+            new = np.asarray(contributions[name])
+            if os.path.exists(filename):
+                prev = np.load(filename)
+                assert prev.shape == new.shape, (name, prev.shape, new.shape)
+                new = self.combine(prev, new, op)
+            self._atomic_save(filename, new)
+
+        count = self.get_num_members(forecast_reference_time) + num_members
+        self._atomic_save(
+            self.get_filename(forecast_reference_time, self.count_name),
+            np.array(count, dtype=np.int64),
+        )
+        utils.LOGGER.debug(
+            f"IntermediateEnsembleAccumulator.accumulate {num_members} members into {directory} in {time.perf_counter() - t0:.1f}s"
+        )
+
+    @staticmethod
+    def combine(prev: np.ndarray, new: np.ndarray, op: str) -> np.ndarray:
+        if op == "sum":
+            return prev + new
+        if op == "min":
+            return np.minimum(prev, new)
+        if op == "max":
+            return np.maximum(prev, new)
+        raise ValueError(f"Unknown reduction '{op}'")
+
+    @staticmethod
+    def _atomic_save(filename: str, array: np.ndarray) -> None:
+        """Write to a temporary file and rename, so a crash cannot leave a partial file"""
+        tmp_filename = filename + ".tmp.npy"
+        np.save(tmp_filename, array)
+        os.replace(tmp_filename, filename)
+
+    def get(self, forecast_reference_time) -> dict[str, np.ndarray]:
+        """Returns the accumulated quantities for this forecast reference time"""
+        ret = {}
+        for name in self.reductions:
+            filename = self.get_filename(forecast_reference_time, name)
+            ret[name] = np.load(filename)
+        return ret
+
+    def get_num_members(self, forecast_reference_time) -> int:
+        """How many members have been accumulated for this forecast reference time?"""
+        filename = self.get_filename(forecast_reference_time, self.count_name)
+        if not os.path.exists(filename):
+            return 0
+        return int(np.load(filename))
+
+    def get_directory(self, forecast_reference_time) -> str:
+        frt_ut = utils.datetime_to_unixtime(forecast_reference_time)
+        return f"{self.workdir}/{frt_ut:.0f}"
+
+    def get_filename(self, forecast_reference_time, name: str) -> str:
+        return f"{self.get_directory(forecast_reference_time)}/{name}.npy"
+
+    def get_forecast_reference_times(self) -> list[np.datetime64]:
+        """Returns all forecast reference times that have been accumulated"""
+        frts = []
+        for directory in glob.glob(f"{self.workdir}/*"):
+            basename = os.path.basename(directory)
+            if os.path.isdir(directory) and basename.isdigit():
+                frts += [utils.unixtime_to_datetime(int(basename))]
+        frts.sort()
+        return frts
+
+    def cleanup(self) -> None:
+        """Removes all intermediate files and the workdir"""
+        t0 = time.perf_counter()
+        for frt in self.get_forecast_reference_times():
+            directory = self.get_directory(frt)
+            for filename in glob.glob(f"{directory}/*.npy"):
+                try:
+                    os.remove(filename)
+                except OSError as e:
+                    utils.LOGGER.warning(f"Error during cleanup of {filename}: {e}")
+            try:
+                os.rmdir(directory)
+            except OSError as e:
+                utils.LOGGER.warning(f"Error removing directory {directory}: {e}")
+        try:
+            os.rmdir(self.workdir)
+        except OSError as e:
+            utils.LOGGER.warning(f"Error removing workdir {self.workdir}: {e}")
+        utils.LOGGER.debug(
+            f"IntermediateEnsembleAccumulator.cleanup in {time.perf_counter() - t0:.1f}s"
+        )

--- a/bris/outputs/netcdf.py
+++ b/bris/outputs/netcdf.py
@@ -575,7 +575,7 @@ class Netcdf(Output):
             from_units = anemoi_conventions.get_units(variable)
             if "units" in attrs:
                 to_units = attrs["units"]
-                ar, _ = bris.units.convert(ar, from_units, to_units, inplace=False)
+                ar = self._convert_units(ar, from_units, to_units)
 
             if level_index is not None:
                 self.ds[ncname][:, level_index, ...] = ar
@@ -585,6 +585,7 @@ class Netcdf(Output):
             # Add variable attributes
             attrs["grid_mapping"] = "projection"
             attrs["coordinates"] = "latitude longitude"
+            attrs.update(self._extra_variable_attrs())
             self.ds[ncname].attrs = attrs
             utils.LOGGER.debug(
                 f"netcdf._setup_prediction_vars variable <{variable}> in {pytime.perf_counter() - t1:.1f}s"
@@ -592,6 +593,18 @@ class Netcdf(Output):
         utils.LOGGER.debug(
             f"netcdf._setup_prediction_vars done in {pytime.perf_counter() - t0:.1f}s"
         )
+
+    def _convert_units(
+        self, ar: np.ndarray, from_units: str, to_units: str
+    ) -> np.ndarray:
+        """Convert a prediction array from anemoi units to output units. Subclasses can
+        override this, e.g. for quantities where only the scale should be converted."""
+        ar, _ = bris.units.convert(ar, from_units, to_units, inplace=False)
+        return ar
+
+    def _extra_variable_attrs(self) -> dict:
+        """Extra attributes to add to every prediction variable. Subclasses can override."""
+        return {}
 
     def _set_attrs(self) -> None:
         """Add global attributes"""

--- a/bris/routes.py
+++ b/bris/routes.py
@@ -1,6 +1,6 @@
 import os
 from collections import defaultdict
-from typing import Any, Literal
+from typing import Any
 
 import numpy as np
 
@@ -63,8 +63,9 @@ def get(
         outputs = []
         for oc in config["outputs"]:
             # If outputing netcdf, add global_attributes with checkpoint name
-            if "netcdf" in oc:
-                oc = add_checkpoint_name_to_attrs(oc, checkpoints)
+            for output_type in ["netcdf", "ensemble_statistics"]:
+                if output_type in oc:
+                    oc = add_checkpoint_name_to_attrs(oc, checkpoints, output_type)
 
             lats = data_module.latitudes[decoder_name][start_gridpoint:end_gridpoint]
             lons = data_module.longitudes[decoder_name][start_gridpoint:end_gridpoint]
@@ -160,17 +161,19 @@ def expand_variable(string: str, variable: str) -> str:
 
 
 def add_checkpoint_name_to_attrs(
-    oc: dict[Literal["netcdf"], dict[str, Any]], checkpoints: dict[str, Checkpoint]
-) -> dict[Literal["netcdf"], dict[str, Any]]:
+    oc: dict[str, dict[str, Any]],
+    checkpoints: dict[str, Checkpoint],
+    output_type: str = "netcdf",
+) -> dict[str, dict[str, Any]]:
     """Add checkpoint name"""
     # oc {'netcdf': {'filename_pattern': './tox_test_inference.nc', 'variables': ['2t', '2d']}}
     ckpt_str = "Checkpoints used: "
-    if "global_attributes" not in oc["netcdf"]:
-        oc["netcdf"]["global_attributes"] = {}
-    if "source" in oc["netcdf"]["global_attributes"]:
-        ckpt_str = f"{oc['netcdf']['global_attributes']['source']} {ckpt_str}"
+    if "global_attributes" not in oc[output_type]:
+        oc[output_type]["global_attributes"] = {}
+    if "source" in oc[output_type]["global_attributes"]:
+        ckpt_str = f"{oc[output_type]['global_attributes']['source']} {ckpt_str}"
     for type, checkpoint in checkpoints.items():
         ckpt_path = os.path.abspath(checkpoint.path)
         ckpt_str += f"{type}:{ckpt_path}, "
-    oc["netcdf"]["global_attributes"]["source"] = f"{ckpt_str}"
+    oc[output_type]["global_attributes"]["source"] = f"{ckpt_str}"
     return oc

--- a/bris/schema/schema.json
+++ b/bris/schema/schema.json
@@ -90,6 +90,56 @@
             "required": ["netcdf"]
         },
 
+        "EnsembleStatisticsOutput": {
+            "description": "Ensemble statistics (mean, std, min, max) to Netcdf, computed by reducing across members batch by batch without storing individual members",
+            "type": "object",
+            "properties": {
+                "ensemble_statistics": {
+                    "type": "object",
+                    "properties": {
+                        "filename_pattern": {
+                            "description": "Where to write the output file. Time tokens allowed (e.g. %Y%m%d). Must contain {statistic} (replaced by e.g. mean) when more than one statistic is written",
+                            "type": "string"
+                        },
+                        "variables": {
+                            "description": "What variables to output? Leave empty to write all",
+                            "type": "array",
+                            "items": {"type": "string"}
+                        },
+                        "extra_variables": {
+                            "description": "Derive these extra variables (use GRIB short names)",
+                            "type": "array",
+                            "items": {"type": "string"}
+                        },
+                        "statistics": {
+                            "description": "Which statistics across the ensemble to write (default: mean and std)",
+                            "type": "array",
+                            "items": {"type": "string", "enum": ["mean", "std", "min", "max"]}
+                        },
+                        "ddof": {
+                            "description": "Delta degrees of freedom for std (0: population, 1: sample). Default 0",
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "proj4_str": {
+                            "description": "Assume this projection string when computing x/y coordinates",
+                            "type": "string"
+                        },
+                        "domain_name": {
+                            "description": "Retrieve projection from this predefined domain name (e.g. meps)",
+                            "type": "string"
+                        },
+                        "global_attributes": {
+                            "description": "Dictionary of global attributes to write to each output file",
+                            "type": "object"
+                        }
+                    },
+                    "required": ["filename_pattern"]
+                }
+            },
+            "required": ["ensemble_statistics"]
+        },
+
         "GribOutput": {
             "description": "Grib output file",
             "type": "object",
@@ -347,7 +397,8 @@
                                 {"$ref": "#/$defs/VerifOutput"},
                                 {"$ref": "#/$defs/GribOutput"},
                                 {"$ref": "#/$defs/SHPowerSpectrumOutput"},
-                                {"$ref": "#/$defs/DCTPowerSpectrum"}
+                                {"$ref": "#/$defs/DCTPowerSpectrum"},
+                                {"$ref": "#/$defs/EnsembleStatisticsOutput"}
                             ]
                         }
                     }

--- a/bris/writer.py
+++ b/bris/writer.py
@@ -3,11 +3,67 @@ from collections.abc import Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
 
 import numpy as np
+import torch
+import torch.distributed as dist
 from pytorch_lightning.callbacks import BasePredictionWriter
 from pytorch_lightning.core.module import LightningModule
 from pytorch_lightning.trainer.trainer import Trainer
 
 from .utils import LOGGER
+
+REDUCE_OPS = {"sum": "SUM", "min": "MIN", "max": "MAX"}
+
+
+def reduce_contributions(
+    contributions: dict[str, np.ndarray],
+    reductions: dict[str, str],
+    group,
+    device=None,
+) -> tuple[dict[str, np.ndarray] | None, int, bool]:
+    """Reduces the contributions from all ranks in group onto the root rank of the group.
+
+    All ranks in the group must call this, in the same order for all outputs, since it performs
+    collective operations.
+
+    Args:
+        contributions: name -> array from this rank
+        reductions: name -> reduction operation ("sum", "min" or "max")
+        group: torch.distributed process group to reduce over (or None, when running without
+            torch.distributed, in which case the contributions are returned unchanged)
+        device: Put tensors on this device before reducing. Required for the nccl backend. If
+            None, the device is chosen based on the backend of the group.
+
+    Returns:
+        reduced: name -> reduced array on the root rank, None on the other ranks
+        num_members: how many ranks (i.e. ensemble members) were reduced
+        is_root: whether this rank is the root of the group
+    """
+    if group is None or not dist.is_available() or not dist.is_initialized():
+        return contributions, 1, True
+
+    world_size = dist.get_world_size(group)
+    if world_size < 1:
+        # This rank is not part of the group, so it has nothing to contribute
+        return None, 0, False
+    if world_size == 1:
+        return contributions, 1, True
+
+    root = dist.get_global_rank(group, 0)
+    is_root = dist.get_rank() == root
+
+    if device is None:
+        device = "cuda" if dist.get_backend(group) == "nccl" else "cpu"
+
+    reduced = {}
+    for name in sorted(contributions.keys()):
+        op = getattr(dist.ReduceOp, REDUCE_OPS[reductions[name]])
+        tensor = torch.from_numpy(np.ascontiguousarray(contributions[name])).to(device)
+        dist.reduce(tensor, dst=root, op=op, group=group)
+        if is_root:
+            reduced[name] = tensor.cpu().numpy()
+        del tensor
+
+    return (reduced if is_root else None), world_size, is_root
 
 
 class CustomWriter(BasePredictionWriter):
@@ -59,7 +115,7 @@ class CustomWriter(BasePredictionWriter):
 
         # Wait for processes from the previous batch to finish
         LOGGER.debug(f"CustomWriter process_list contains {self.process_list}")
-        while len(self.process_list) > 0:
+        while self.process_list is not None and len(self.process_list) > 0:
             LOGGER.debug(
                 "CustomWriter waiting for previous process to complete before writing new data."
             )
@@ -81,7 +137,11 @@ class CustomWriter(BasePredictionWriter):
                 ]
 
                 for output in output_dict["outputs"]:
-                    if self.process_list is not None:
+                    if getattr(output, "reduce_across_members", False):
+                        self._add_reduced_forecast(
+                            output, pl_module, times, ensemble_member, pred, batch_idx
+                        )
+                    elif self.process_list is not None:
                         self.process_list.append(
                             self.pool.submit(
                                 output.add_forecast, times, ensemble_member, pred
@@ -95,6 +155,44 @@ class CustomWriter(BasePredictionWriter):
                         LOGGER.debug(
                             f"CustomWriter added forecast for member <{ensemble_member}>, times {times} for writing, batch_idx {batch_idx}."
                         )
+
+    def _add_reduced_forecast(
+        self,
+        output,
+        pl_module: LightningModule | None,
+        times: list,
+        ensemble_member: int,
+        pred: np.ndarray,
+        batch_idx: int,
+    ) -> None:
+        """Reduces this member's contribution to output across the ensemble members that run in
+        parallel, and registers the result with the output on the ensemble-root rank.
+
+        The contribution and the reduction are done synchronously in the calling thread, since
+        the reduction is a collective operation that must be issued in the same order on all
+        ranks. Only the (cheap) storing of the reduced result is done in the background.
+        """
+        contributions = output.member_contribution(times, ensemble_member, pred)
+
+        group = getattr(pl_module, "ens_output_comm_group", None)
+        device = getattr(pl_module, "device", None)
+        reduced, num_members, is_root = reduce_contributions(
+            contributions, output.ensemble_reductions, group, device
+        )
+        LOGGER.debug(
+            f"CustomWriter reduced member <{ensemble_member}> contribution across {num_members} members, times {times}, batch_idx {batch_idx}."
+        )
+        if not is_root:
+            return
+
+        if self.process_list is not None:
+            self.process_list.append(
+                self.pool.submit(
+                    output.add_reduced_forecast, times, reduced, num_members
+                )
+            )
+        else:
+            output.add_reduced_forecast(times, reduced, num_members)
 
     def on_predict_end(
         self,

--- a/tests/test_outputs_ensemble_statistics.py
+++ b/tests/test_outputs_ensemble_statistics.py
@@ -1,0 +1,210 @@
+import os
+import tempfile
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from bris.conventions.variable_list import VariableList
+from bris.outputs import EnsembleStatistics
+from bris.predict_metadata import PredictMetadata
+
+VARIABLES = ["2t", "10u", "10v", "tp"]
+EXTRA_VARIABLES = ["ws"]
+NUM_MEMBERS = 4
+LEADTIMES = np.arange(0, 3600 * 3, 3600)
+FRT = 1672552800
+
+
+def get_pm(gridded: bool, num_members: int = NUM_MEMBERS) -> PredictMetadata:
+    if gridded:
+        lats = np.arange(50, 55)
+        lons = np.arange(5, 8)
+        field_shape = [len(lats), len(lons)]
+        lats, lons = np.meshgrid(lats, lons, indexing="ij")
+        lats = lats.flatten()
+        lons = lons.flatten()
+    else:
+        lats = np.array([50, 51, 52, 53, 54, 55, 56])
+        lons = np.array([5, 6, 7, 8, 9, 10, 11])
+        field_shape = (len(lats),)
+    return PredictMetadata(
+        VARIABLES, lats, lons, None, LEADTIMES, num_members, field_shape
+    )
+
+
+def get_predictions(pm: PredictMetadata, seed: int = 0) -> np.ndarray:
+    """Random forecasts with dimensions (member, leadtime, location, variable)"""
+    rng = np.random.default_rng(seed)
+    pred = rng.random((pm.num_members, *pm.shape)).astype(np.float32)
+    pred[..., 0] += 273  # 2t in K
+    return pred
+
+
+def expected_statistics(pred: np.ndarray, ddof: int = 0) -> dict:
+    """Expected statistics with dimensions (leadtime, location, variable) including ws"""
+    ws = np.sqrt(pred[..., [1]] ** 2 + pred[..., [2]] ** 2)
+    pred = np.concatenate([pred, ws], axis=-1)
+    return {
+        "mean": pred.mean(axis=0),
+        "std": pred.std(axis=0, ddof=ddof),
+        "min": pred.min(axis=0),
+        "max": pred.max(axis=0),
+    }
+
+
+def check_file(filename: str, expected: np.ndarray, pm: PredictMetadata, statistic):
+    """Checks that the written statistic matches the expected (leadtime, location, variable)"""
+    variable_list = VariableList(VARIABLES + EXTRA_VARIABLES)
+    with xr.open_dataset(filename) as ds:
+        assert "ensemble_member" not in ds.dims
+        for v, variable in enumerate(VARIABLES + EXTRA_VARIABLES):
+            ncname = variable_list.get_ncname_from_anemoi_name(variable)
+            assert ncname in ds, ncname
+            values = ds[ncname].values
+            assert ds[ncname].attrs["cell_methods"].startswith("realization: ")
+            if pm.is_gridded:
+                values = values.reshape(pm.num_leadtimes, -1, pm.num_points)
+            else:
+                values = values.reshape(pm.num_leadtimes, -1, pm.num_points)
+            # Squeeze out the level dimension, if any
+            values = values[:, 0, :] if values.shape[1] == 1 else values
+            curr = expected[..., v]
+            if variable == "tp":
+                # Anemoi uses Mg/m^2, output is kg/m^2. Both mean and std are scaled, since
+                # the conversion is linear
+                curr = curr * 1000
+            np.testing.assert_allclose(values, curr, rtol=1e-5, atol=1e-4)
+
+
+@pytest.mark.parametrize("gridded", [True, False])
+@pytest.mark.parametrize("ddof", [0, 1])
+def test_sequential_members(gridded, ddof):
+    """Members added one at a time through add_forecast (the non-reduced path)"""
+    pm = get_pm(gridded)
+    pred = get_predictions(pm)
+    statistics = ["mean", "std", "min", "max"]
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        pattern = os.path.join(temp_dir, "ens_{statistic}_%Y%m%dT%HZ.nc")
+        output = EnsembleStatistics(
+            pm,
+            os.path.join(temp_dir, "workdir"),
+            pattern,
+            variables=VARIABLES,
+            extra_variables=EXTRA_VARIABLES,
+            statistics=statistics,
+            ddof=ddof,
+        )
+        times = [np.datetime64(FRT, "s") + lt for lt in LEADTIMES]
+        for member in range(NUM_MEMBERS):
+            output.add_forecast(times, member, pred[member])
+        output.finalize()
+
+        expected = expected_statistics(pred, ddof)
+        for statistic in statistics:
+            filename = output.writers[statistic].get_filename(FRT)
+            assert os.path.exists(filename), filename
+            assert f"ens_{statistic}_2023" in filename
+            check_file(filename, expected[statistic], pm, statistic)
+
+        # Intermediate is cleaned up
+        assert not os.path.exists(os.path.join(temp_dir, "workdir"))
+
+
+def test_reduced_members():
+    """Members reduced in two groups (as when members run both in parallel and in sequence),
+    over several forecast reference times"""
+    pm = get_pm(gridded=True)
+    statistics = ["mean", "std"]
+    frts = [FRT, FRT + 6 * 3600]
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        pattern = os.path.join(temp_dir, "ens_{statistic}_%Y%m%dT%HZ.nc")
+        output = EnsembleStatistics(
+            pm,
+            os.path.join(temp_dir, "workdir"),
+            pattern,
+            variables=VARIABLES,
+            extra_variables=EXTRA_VARIABLES,
+            statistics=statistics,
+        )
+        preds = {}
+        for i, frt in enumerate(frts):
+            preds[frt] = get_predictions(pm, seed=i)
+            times = [np.datetime64(frt, "s") + lt for lt in LEADTIMES]
+            # Two groups of two members, reduced like the writer would do it
+            for members in [[0, 1], [2, 3]]:
+                contributions = [
+                    output.member_contribution(times, m, preds[frt][m]) for m in members
+                ]
+                reduced = {
+                    "sum": sum(c["sum"] for c in contributions),
+                    "sum_sq": sum(c["sum_sq"] for c in contributions),
+                    "min": np.minimum(*[c["min"] for c in contributions]),
+                    "max": np.maximum(*[c["max"] for c in contributions]),
+                }
+                output.add_reduced_forecast(times, reduced, len(members))
+            assert output.intermediate.get_num_members(times[0]) == NUM_MEMBERS
+
+        output.finalize()
+
+        for frt in frts:
+            expected = expected_statistics(preds[frt])
+            for statistic in statistics:
+                filename = output.writers[statistic].get_filename(frt)
+                check_file(filename, expected[statistic], pm, statistic)
+
+
+def test_member_contribution_shapes():
+    pm = get_pm(gridded=True)
+    pred = get_predictions(pm)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output = EnsembleStatistics(
+            pm,
+            os.path.join(temp_dir, "workdir"),
+            os.path.join(temp_dir, "mean.nc"),
+            variables=["2t"],
+            statistics=["mean"],
+        )
+        times = [np.datetime64(FRT, "s") + lt for lt in LEADTIMES]
+        contributions = output.member_contribution(times, 0, pred[0])
+        assert set(contributions.keys()) == set(output.ensemble_reductions.keys())
+        for value in contributions.values():
+            # Only the requested variables are accumulated
+            assert value.shape == (pm.num_leadtimes, pm.num_points, 1)
+            assert value.dtype == np.float64
+        np.testing.assert_allclose(contributions["sum"][..., 0], pred[0][..., 0])
+        np.testing.assert_allclose(
+            contributions["sum_sq"][..., 0], pred[0][..., 0].astype(np.float64) ** 2
+        )
+
+
+def test_invalid_config():
+    pm = get_pm(gridded=True)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        workdir = os.path.join(temp_dir, "workdir")
+        # Several statistics need the {statistic} token
+        with pytest.raises(ValueError):
+            EnsembleStatistics(
+                pm,
+                workdir,
+                os.path.join(temp_dir, "out.nc"),
+                statistics=["mean", "std"],
+            )
+        with pytest.raises(ValueError):
+            EnsembleStatistics(
+                pm, workdir, os.path.join(temp_dir, "out.nc"), statistics=["median"]
+            )
+        with pytest.raises(ValueError):
+            EnsembleStatistics(
+                pm, workdir, os.path.join(temp_dir, "out.nc"), variables=["2d"]
+            )
+        # A single statistic does not need the token
+        EnsembleStatistics(
+            pm, workdir, os.path.join(temp_dir, "out.nc"), statistics=["mean"]
+        )
+
+
+if __name__ == "__main__":
+    _ = pytest.main([__file__])

--- a/tests/test_outputs_intermediate.py
+++ b/tests/test_outputs_intermediate.py
@@ -1,6 +1,8 @@
+import os
 import tempfile
 
 import numpy as np
+import pytest
 
 from bris.outputs.intermediate import Intermediate
 from bris.predict_metadata import PredictMetadata
@@ -29,3 +31,55 @@ def test_num_members():
         i = Intermediate(predict_metadata=get_test_pm(), workdir=temp_dir)
         # Checking the num_members property
         assert i.num_members == 3
+
+
+def test_ensemble_accumulator():
+    from bris.outputs.intermediate import IntermediateEnsembleAccumulator
+
+    reductions = {"sum": "sum", "lowest": "min", "highest": "max"}
+    frt1 = np.datetime64("2023-01-01T06:00:00")
+    frt2 = np.datetime64("2023-01-01T00:00:00")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        workdir = f"{temp_dir}/workdir"
+        acc = IntermediateEnsembleAccumulator(workdir, reductions)
+        assert acc.get_forecast_reference_times() == []
+        assert acc.get_num_members(frt1) == 0
+
+        a = np.array([[1.0, 5.0], [3.0, -1.0]])
+        b = np.array([[2.0, 1.0], [0.0, 4.0]])
+        acc.accumulate(frt1, {"sum": a, "lowest": a, "highest": a}, 2)
+        acc.accumulate(frt1, {"sum": b, "lowest": b, "highest": b}, 3)
+        acc.accumulate(frt2, {"sum": b, "lowest": b, "highest": b}, 1)
+
+        assert acc.get_num_members(frt1) == 5
+        assert acc.get_num_members(frt2) == 1
+        # Sorted, regardless of insertion order
+        assert acc.get_forecast_reference_times() == [frt2, frt1]
+
+        result = acc.get(frt1)
+        np.testing.assert_array_equal(result["sum"], a + b)
+        np.testing.assert_array_equal(result["lowest"], np.minimum(a, b))
+        np.testing.assert_array_equal(result["highest"], np.maximum(a, b))
+
+        # No temporary files left behind
+        assert all(
+            not f.endswith(".tmp.npy") for f in os.listdir(acc.get_directory(frt1))
+        )
+
+        acc.cleanup()
+        assert not os.path.exists(workdir)
+
+
+def test_ensemble_accumulator_invalid():
+    from bris.outputs.intermediate import IntermediateEnsembleAccumulator
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with pytest.raises(ValueError):
+            IntermediateEnsembleAccumulator(temp_dir, {"sum": "mean"})
+        with pytest.raises(ValueError):
+            IntermediateEnsembleAccumulator(temp_dir, {"num_members": "sum"})
+        acc = IntermediateEnsembleAccumulator(temp_dir, {"sum": "sum"})
+        with pytest.raises(AssertionError):
+            acc.accumulate(
+                np.datetime64("2023-01-01T00:00:00"), {"other": np.ones(2)}, 1
+            )

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,11 +1,16 @@
+import os
+import tempfile
 import time
 from concurrent.futures import Future
 from queue import Queue
 
 import numpy as np
 import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
 
-from bris.writer import CustomWriter
+from bris.writer import CustomWriter, reduce_contributions
 
 
 class DummyOutput:
@@ -56,6 +61,112 @@ def test_custom_writer_async(prediction):
     times, member, pred = calls.get()
     assert member == 0
     np.testing.assert_array_equal(pred, np.ones((2, 3)))
+
+
+class DummyReducedOutput:
+    """Output using the ensemble-reduction protocol"""
+
+    reduce_across_members = True
+    ensemble_reductions = {"sum": "sum", "max": "max"}
+
+    def __init__(self, calls):
+        self.calls = calls
+
+    def member_contribution(self, times, ensemble_member, pred):
+        return {"sum": pred, "max": pred}
+
+    def add_forecast(self, times, ensemble_member, pred):
+        raise AssertionError("add_forecast should not be called for reduced outputs")
+
+    def add_reduced_forecast(self, times, contributions, num_members):
+        self.calls.put((times, contributions, num_members))
+
+
+@pytest.mark.parametrize("background", [True, False])
+def test_custom_writer_reduced_output(prediction, background):
+    """Without torch.distributed, a reduced output gets its own contribution unchanged"""
+    calls = Queue()
+    output = DummyReducedOutput(calls)
+    output_dict = [
+        {
+            "decoder_name": "data",
+            "start_gridpoint": 0,
+            "end_gridpoint": 2,
+            "outputs": [output],
+        }
+    ]
+    thread_list = [] if background else None
+    writer = CustomWriter(output_dict, thread_list)
+    writer.write_on_batch_end(None, None, prediction, None, None, 0, 0)
+    if background:
+        assert len(thread_list) == 1
+        for thread in thread_list:
+            thread.result()
+
+    assert calls.qsize() == 1
+    times, contributions, num_members = calls.get()
+    assert num_members == 1
+    assert set(contributions.keys()) == {"sum", "max"}
+    np.testing.assert_array_equal(contributions["sum"], np.ones((2, 3)))
+
+
+def test_reduce_contributions_no_group():
+    contributions = {"sum": np.ones(3), "min": np.zeros(3)}
+    reduced, num_members, is_root = reduce_contributions(
+        contributions, {"sum": "sum", "min": "min"}, None
+    )
+    assert num_members == 1
+    assert is_root
+    assert reduced is contributions
+
+
+def _reduce_worker(rank, world_size, init_file, result_dir):
+    dist.init_process_group(
+        "gloo", init_method=f"file://{init_file}", rank=rank, world_size=world_size
+    )
+    try:
+        group = dist.new_group(list(range(world_size)))
+        contributions = {
+            "sum": np.full((2, 3), rank + 1, dtype=np.float64),
+            "min": np.full((2, 3), rank + 1, dtype=np.float64),
+            "max": np.full((2, 3), rank + 1, dtype=np.float64),
+        }
+        reduced, num_members, is_root = reduce_contributions(
+            contributions, {"sum": "sum", "min": "min", "max": "max"}, group, "cpu"
+        )
+        np.save(f"{result_dir}/num_members_{rank}.npy", num_members)
+        np.save(f"{result_dir}/is_root_{rank}.npy", is_root)
+        if reduced is not None:
+            for name, value in reduced.items():
+                np.save(f"{result_dir}/{name}_{rank}.npy", value)
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(not dist.is_available(), reason="torch.distributed not available")
+def test_reduce_contributions_gloo():
+    """Reduce across 3 CPU processes: only the root gets the result"""
+    world_size = 3
+    with tempfile.TemporaryDirectory() as temp_dir:
+        init_file = os.path.join(temp_dir, "init")
+        mp.spawn(
+            _reduce_worker,
+            args=(world_size, init_file, temp_dir),
+            nprocs=world_size,
+            join=True,
+        )
+        for rank in range(world_size):
+            assert int(np.load(f"{temp_dir}/num_members_{rank}.npy")) == world_size
+            assert bool(np.load(f"{temp_dir}/is_root_{rank}.npy")) == (rank == 0)
+            if rank > 0:
+                assert not os.path.exists(f"{temp_dir}/sum_{rank}.npy")
+        np.testing.assert_array_equal(
+            np.load(f"{temp_dir}/sum_0.npy"), np.full((2, 3), 1 + 2 + 3)
+        )
+        np.testing.assert_array_equal(np.load(f"{temp_dir}/min_0.npy"), np.ones((2, 3)))
+        np.testing.assert_array_equal(
+            np.load(f"{temp_dir}/max_0.npy"), np.full((2, 3), 3)
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Outputs can now opt in to an ensemble-reduction protocol (reduce_across_members = True): instead of receiving one member at a time, each member's contribution (e.g. x, x^2, min, max) is reduced across the members that run in parallel with torch.distributed, and only the ensemble-root rank stores the reduced result. Members that run in sequence are accumulated on disk per forecast reference time (IntermediateEnsembleAccumulator), so the intermediate storage and the memory needed in finalize are independent of the number of members.

- DDPGroupStrategy creates a process group of the output-writing ranks within each ensemble group; BasePredictor exposes it as ens_output_comm_group.
- CustomWriter reduces contributions synchronously (collectives must be issued in the same order on all ranks) and stores them in the background on the root rank.
- New ensemble_statistics output writes ensemble mean/std/min/max to NetCDF, reusing the netcdf writer (one file per statistic, with CF cell_methods). Standard deviations only get the scale part of unit conversions.
- Fix CustomWriter crashing when background_write is false.
- Schema, README and tests (including a 3-process gloo reduction test).