### PR TITLE
Clear cached sharding state when loading a checkpoint

### DIFF
--- a/bris/checkpoint.py
+++ b/bris/checkpoint.py
@@ -148,21 +148,7 @@ class Checkpoint:
     )
 
     def _clear_sharding_caches(self, model: torch.nn.Module) -> None:
-        """Drop halo/partition caches that were pickled into the checkpoint.
-
-        When a model is trained with model sharding (num_gpus_per_model > 1), the
-        GraphTransformer processor blocks cache halo exchange metadata (edge indices,
-        send indices, ...) as plain attributes. Saving the model with torch.save()
-        pickles these caches, and torch.load(map_location="cpu") restores them on
-        CPU. Because they are not registered buffers, moving the model to the GPU
-        leaves them behind. If the inference sharding layout matches the training
-        layout, the cache key matches and the CPU tensors are fed to the Triton
-        attention kernel, which fails with
-        "Pointer argument cannot be accessed from Triton (cpu tensor?)".
-
-        The caches are pure derived state, so dropping them is safe: they are
-        rebuilt on the correct device on the first forward pass.
-        """
+        """Drop halo/partition caches that were pickled into the checkpoint."""
         cleared = 0
         for module in model.modules():
             for attr in self._SHARDING_CACHE_ATTRS:

--- a/bris/checkpoint.py
+++ b/bris/checkpoint.py
@@ -134,7 +134,48 @@ class Checkpoint:
             raise e
         if not torch.cuda.is_available():
             self._apply_triton_cpu_fallback(inst)
+        self._clear_sharding_caches(inst)
         return inst
+
+    # Attributes anemoi-models processor blocks use to cache per-rank halo exchange
+    # metadata when the model is sharded across GPUs. They are plain attributes
+    # (not registered buffers), so torch.load restores them on CPU and .to(device)
+    # does not move them.
+    _SHARDING_CACHE_ATTRS = (
+        "_cached_halo_info",
+        "_cached_partition",
+        "_cached_halo_cache_specs",
+    )
+
+    def _clear_sharding_caches(self, model: torch.nn.Module) -> None:
+        """Drop halo/partition caches that were pickled into the checkpoint.
+
+        When a model is trained with model sharding (num_gpus_per_model > 1), the
+        GraphTransformer processor blocks cache halo exchange metadata (edge indices,
+        send indices, ...) as plain attributes. Saving the model with torch.save()
+        pickles these caches, and torch.load(map_location="cpu") restores them on
+        CPU. Because they are not registered buffers, moving the model to the GPU
+        leaves them behind. If the inference sharding layout matches the training
+        layout, the cache key matches and the CPU tensors are fed to the Triton
+        attention kernel, which fails with
+        "Pointer argument cannot be accessed from Triton (cpu tensor?)".
+
+        The caches are pure derived state, so dropping them is safe: they are
+        rebuilt on the correct device on the first forward pass.
+        """
+        cleared = 0
+        for module in model.modules():
+            for attr in self._SHARDING_CACHE_ATTRS:
+                if getattr(module, attr, None) is not None:
+                    setattr(module, attr, None)
+                    cleared += 1
+
+        if cleared:
+            LOGGER.info(
+                "Cleared %d cached sharding attribute(s) restored from the checkpoint; "
+                "they will be rebuilt on the inference device.",
+                cleared,
+            )
 
     def _apply_triton_cpu_fallback(self, model: torch.nn.Module) -> None:
         """Replace Triton graph attention with the PyG backend when running on CPU.


### PR DESCRIPTION
Models trained with model sharding (num_gpus_per_model > 1) cache halo exchange metadata (edge indices, send indices, partition) on the GraphTransformer processor blocks as plain attributes. torch.save() pickles these caches and torch.load(map_location="cpu") restores them on CPU. They are not registered buffers, so moving the model to the GPU leaves them behind. When the inference sharding layout matches the training layout the cache key matches, the CPU edge index is reused, and the Triton attention kernel fails with
"Pointer argument cannot be accessed from Triton (cpu tensor?)".

Drop these caches right after loading; they are derived state and are rebuilt on the correct device on the first forward pass.