### PR TITLE
Add bris-obs: Verif observation files from anemoi-datasets zarr stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,6 @@ the [Anemoi framework](https://github.com/ecmwf/anemoi-training).
 
 See [Wiki](https://github.com/metno/bris-inference/wiki)
 
-## Verifying against an analysis dataset
-
-`bris-obs --config obs.yaml` extracts a subset of points from an anemoi-datasets zarr
-store over a period and writes one Verif observation file per variable. Point the
-`verif` observation source of the `verif` output at these files to verify forecasts
-against the analysis. The config takes an open_dataset-style `dataset` recipe (a
-path, `join` of stores on the same grid, `area`, `frequency`, `every_loc` or `spacing`) and a list of
-`verif` outputs (`filename`, `variable`, `units`); see `config/verif_obs_template.yaml`.
-The stores are read directly, so other open_dataset operations are not supported.
-
 ## Requirements
 
 - Running on ARM/MacOS requires some workarounds for now: https://github.com/metno/bris-inference/issues/85

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See [Wiki](https://github.com/metno/bris-inference/wiki)
 store over a period and writes one Verif observation file per variable. Point the
 `verif` observation source of the `verif` output at these files to verify forecasts
 against the analysis. The config takes an open_dataset-style `dataset` recipe (a
-path, `join` of stores on the same grid, `area`, `every_loc` or `spacing`) and a list of
+path, `join` of stores on the same grid, `area`, `frequency`, `every_loc` or `spacing`) and a list of
 `verif` outputs (`filename`, `variable`, `units`); see `config/verif_obs_template.yaml`.
 The stores are read directly, so other open_dataset operations are not supported.
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ See [Wiki](https://github.com/metno/bris-inference/wiki)
 `bris-obs --config obs.yaml` extracts a subset of points from an anemoi-datasets zarr
 store over a period and writes one Verif observation file per variable. Point the
 `verif` observation source of the `verif` output at these files to verify forecasts
-against the analysis. See `config/verif_obs_template.yaml` and the docstring of
-`bris/obs.py` for the config format.
+against the analysis. The config takes an open_dataset-style `dataset` recipe (a
+path, `join` of stores on the same grid, `area`, `every_loc` or `spacing`) and a list of
+`verif` outputs (`filename`, `variable`, `units`); see `config/verif_obs_template.yaml`.
+The stores are read directly, so other open_dataset operations are not supported.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,19 @@ the [Anemoi framework](https://github.com/ecmwf/anemoi-training).
 - Multi encoder/decoder
 - Time interpolation
 - Ensembles
+- Verification observation files from analysis datasets (`bris-obs`)
 
 ## Documentation
 
 See [Wiki](https://github.com/metno/bris-inference/wiki)
+
+## Verifying against an analysis dataset
+
+`bris-obs --config obs.yaml` extracts a subset of points from an anemoi-datasets zarr
+store over a period and writes one Verif observation file per variable. Point the
+`verif` observation source of the `verif` output at these files to verify forecasts
+against the analysis. See `config/verif_obs_template.yaml` and the docstring of
+`bris/obs.py` for the config format.
 
 ## Requirements
 

--- a/bris/obs.py
+++ b/bris/obs.py
@@ -10,6 +10,7 @@ from multiprocessing import Pool
 from pathlib import Path
 
 import numpy as np
+from anemoi.utils.dates import frequency_to_seconds
 from omegaconf import OmegaConf
 
 from bris import units as bris_units
@@ -163,6 +164,7 @@ RECIPE_KEYS = {
     "area",
     "start",
     "end",
+    "frequency",
     "every_loc",
     "every",
     "spacing",
@@ -174,14 +176,16 @@ def parse_recipe(recipe) -> dict:
 
     Supported: a zarr path, ``{dataset: <recipe>}``, ``{join: [<recipe>, ...]}`` (stores on the
     same grid and dates), and the options ``area`` [N, W, S, E], ``start``, ``end``,
-    ``every_loc`` (index stride) and ``spacing`` (degrees), at any level. Other open_dataset
-    operations are not supported, since the stores are read directly.
+    ``frequency`` (e.g. "6h", a multiple of the dataset's own step), ``every_loc`` (index
+    stride) and ``spacing`` (degrees), at any level. Other open_dataset operations are not
+    supported, since the stores are read directly.
     """
     result = {
         "paths": [],
         "area": None,
         "start": None,
         "end": None,
+        "frequency": None,
         "every": None,
         "spacing": None,
     }
@@ -219,6 +223,7 @@ def parse_recipe(recipe) -> dict:
         merge("area", node.get("area"))
         merge("start", node.get("start"))
         merge("end", node.get("end"))
+        merge("frequency", node.get("frequency"))
         merge("every", node.get("every_loc", node.get("every")))
         merge("spacing", node.get("spacing"))
 
@@ -255,25 +260,38 @@ def run(config) -> list[Path]:
                     f"dataset {path}: '{key}' differs from the first dataset {paths[0]}"
                 )
 
-    # ---- period: recipe start/end, else the config's start_date/end_date ------------------
+    # ---- period: recipe start/end, else the config's start_date/end_date, else all dates ---
     start = recipe["start"] or config.get("start_date")
     end = recipe["end"] or config.get("end_date")
-    if start is None or end is None:
-        raise ValueError(
-            "period not set: give start_date/end_date or start/end in the dataset recipe"
-        )
-    start = np.datetime64(str(start), "s")
-    end = np.datetime64(str(end), "s")
+    start = np.datetime64(str(start), "s") if start is not None else dates[0]
+    end = np.datetime64(str(end), "s") if end is not None else dates[-1]
     t_indices = np.flatnonzero((dates >= start) & (dates <= end))
     if len(t_indices) == 0:
         raise ValueError(
             f"no dates in [{start}, {end}]; dataset covers {dates[0]} .. {dates[-1]}"
         )
+
+    # ---- frequency: subsample the dataset's dates (default: keep them all) ---------------
+    frequency = recipe["frequency"] or config.get("frequency")
+    if frequency is not None:
+        step = frequency_to_seconds(frequency)
+        seconds = (
+            (dates[t_indices] - dates[t_indices[0]])
+            .astype("timedelta64[s]")
+            .astype(np.int64)
+        )
+        native = int(np.min(np.diff(seconds))) if len(seconds) > 1 else step
+        if step < native or step % native != 0:
+            raise ValueError(
+                f"frequency {frequency} is not a multiple of the dataset frequency ({native} s)"
+            )
+        t_indices = t_indices[seconds % step == 0]
     LOGGER.info(
-        "%d timesteps: %s .. %s",
+        "%d timesteps: %s .. %s%s",
         len(t_indices),
         dates[t_indices[0]],
         dates[t_indices[-1]],
+        f" (every {frequency})" if frequency is not None else "",
     )
 
     # ---- points ---------------------------------------------------------------------------

--- a/bris/obs.py
+++ b/bris/obs.py
@@ -1,0 +1,379 @@
+"""Create Verif observation files from anemoi-datasets zarr stores.
+
+    bris-obs --config obs.yaml
+
+Extracts a set of grid points from an analysis dataset over a period and writes one
+Verif file per variable (dimensions ``time`` and ``location``), which the ``verif``
+observation source of the ``verif`` output can read. This makes it possible to verify
+forecasts against analyses at a subset of points without reading the full dataset at
+inference time.
+
+Example config::
+
+    start_date: 2023-01-01T00:00:00
+    end_date: 2023-12-31T18:00:00
+    output: /path/to/verification/{name}/analysis.nc   # {name} is replaced per output
+    workers: 16                                        # parallel readers (1 = in-process)
+
+    points:
+      area: [40, -25, -40, 55]   # N, W, S, E (optional, whole grid if omitted)
+      spacing: 2.5               # nearest grid point to each node of a regular lat/lon grid
+      # every: 1000              # alternative: every n-th grid point (index stride)
+
+    datasets:                    # zarr paths; the first defines grid, dates and altitudes (z)
+      - /path/to/analysis.zarr
+      - /path/to/analysis-extra-variables.zarr   # same grid and dates, e.g. cloud variables
+
+    outputs:
+      - {name: t2m, variable: 2t, units: degC}
+      - {name: mslp, variable: msl, units: hPa}
+      - {name: precip6h, variable: tp, units: mm}
+      - {name: ws10m, variable: ws}             # derived from 10u/10v; anemoi units kept
+      - {name: tcc, variable: tcc}
+
+The zarr stores are read directly (one chunk decompression per timestep and chunk of
+variables), which is orders of magnitude faster than going through
+``anemoi.datasets.open_dataset`` with an ``area`` crop for point subsets. Only plain zarr
+stores are supported for that reason, not open_dataset recipes.
+
+Point selection: ``spacing`` picks, for each node of a regular latitude/longitude grid
+over the area, the nearest dataset grid point (even coverage, every point is a real grid
+point). ``every`` keeps every n-th point in storage order; on reduced Gaussian grids this
+aliases with the row length and gives very uneven coverage, so ``spacing`` is preferred.
+The ``location`` id is the index of the point in the (area-cropped) grid.
+"""
+
+import json
+import logging
+import sys
+import time
+from argparse import ArgumentParser
+from datetime import datetime, timezone
+from multiprocessing import Pool
+from pathlib import Path
+
+import numpy as np
+from omegaconf import OmegaConf
+
+from bris import units as bris_units
+from bris.conventions import anemoi as anemoi_conventions
+from bris.conventions import cf
+
+LOGGER = logging.getLogger(__name__)
+
+GRAVITY = 9.81  # same constant as the anemoidataset source uses for z -> altitude
+DERIVED_VARIABLES = {"ws": ("10u", "10v")}
+
+_STORES: dict = {}  # per-process zarr handles, keyed by path
+
+
+def _open_zarr(path: str):
+    import zarr
+
+    return zarr.open(path, mode="r")
+
+
+def _worker_init(paths: list[str]) -> None:
+    global _STORES
+    _STORES = {path: _open_zarr(path) for path in paths}
+
+
+def _read_step(args) -> tuple[int, np.ndarray]:
+    """Read one time index for all planned (dataset, variable) rows at the selected points.
+
+    Args:
+        args: (time index, plan, point index), where plan maps a zarr path to a list of
+            (output row, variable index in that store) tuples.
+    """
+    t_index, plan, point_index = args
+    n_rows = sum(len(rows) for rows in plan.values())
+    out = np.full((n_rows, len(point_index)), np.nan, dtype=np.float32)
+    for path, rows in plan.items():
+        data = _STORES[path]["data"]
+        # Variables are chunked in groups; decompress each chunk once for all rows in it
+        vchunk = data.chunks[1]
+        for group in sorted({v // vchunk for _, v in rows}):
+            lo, hi = group * vchunk, min((group + 1) * vchunk, data.shape[1])
+            block = data[t_index, lo:hi, 0, :]
+            for row, v in rows:
+                if lo <= v < hi:
+                    out[row] = block[v - lo, point_index]
+    return t_index, out
+
+
+def _wrap_longitudes(lon: np.ndarray) -> np.ndarray:
+    lon = np.asarray(lon, dtype=np.float64)
+    return ((lon + 180.0) % 360.0) - 180.0
+
+
+def _xyz(lat_deg: np.ndarray, lon_deg: np.ndarray) -> np.ndarray:
+    la, lo = np.deg2rad(lat_deg), np.deg2rad(lon_deg)
+    return np.column_stack([np.cos(la) * np.cos(lo), np.cos(la) * np.sin(lo), np.sin(la)])
+
+
+def select_points(
+    lat: np.ndarray,
+    lon: np.ndarray,
+    area: list | tuple | None = None,
+    spacing: float | None = None,
+    every: int | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Select observation points from a grid.
+
+    Args:
+        lat, lon: grid coordinates (degrees, any longitude convention)
+        area: [N, W, S, E] bounding box in degrees (longitudes in -180..180), or None
+        spacing: keep the nearest grid point to each node of a regular lat/lon grid with
+            this spacing (degrees) over the area
+        every: keep every n-th point of the (cropped) grid in storage order
+
+    Returns:
+        global_index: indices into the full grid
+        location_id: indices into the cropped grid (used as Verif location ids)
+    """
+    lat = np.asarray(lat, dtype=np.float64)
+    lon180 = _wrap_longitudes(lon)
+
+    if area is not None:
+        north, west, south, east = (float(x) for x in area)
+        if north <= south:
+            raise ValueError(f"area must be [N, W, S, E] with N > S, got {list(area)}")
+        in_lat = (lat <= north) & (lat >= south)
+        if west <= east:
+            in_lon = (lon180 >= west) & (lon180 <= east)
+        else:  # box crossing the date line
+            in_lon = (lon180 >= west) | (lon180 <= east)
+        cropped = np.flatnonzero(in_lat & in_lon)
+    else:
+        north, west, south, east = 90.0, -180.0, -90.0, 180.0
+        cropped = np.arange(len(lat))
+
+    if len(cropped) == 0:
+        raise ValueError(f"no grid points inside area {list(area)}")
+
+    if spacing is not None and every is not None:
+        raise ValueError("points: give either 'spacing' or 'every', not both")
+
+    if spacing is not None:
+        from scipy.spatial import cKDTree
+
+        spacing = float(spacing)
+        if spacing <= 0:
+            raise ValueError("points.spacing must be positive")
+        target_lat = np.arange(south, north + 1e-9, spacing)
+        if area is None:
+            target_lon = np.arange(-180.0, 180.0, spacing)
+        elif west <= east:
+            target_lon = np.arange(west, east + 1e-9, spacing)
+        else:
+            target_lon = _wrap_longitudes(np.arange(west, east + 360.0 + 1e-9, spacing))
+        tlat, tlon = np.meshgrid(target_lat, target_lon, indexing="ij")
+        tree = cKDTree(_xyz(lat[cropped], lon180[cropped]))
+        _, nearest = tree.query(_xyz(tlat.ravel(), tlon.ravel()))
+        location_id = np.unique(nearest)
+    elif every is not None:
+        every = int(every)
+        if every < 1:
+            raise ValueError("points.every must be >= 1")
+        if every > 1:
+            LOGGER.warning(
+                "points.every keeps every %d-th point in storage order; on reduced Gaussian "
+                "grids this aliases with the row length and gives uneven coverage. "
+                "Consider points.spacing instead.",
+                every,
+            )
+        location_id = np.arange(0, len(cropped), every)
+    else:
+        location_id = np.arange(len(cropped))
+
+    return cropped[location_id], location_id
+
+
+def _unixtime(dates: np.ndarray) -> np.ndarray:
+    dates = np.asarray(dates).astype("datetime64[s]")
+    return (dates - np.datetime64("1970-01-01T00:00:00", "s")).astype(np.int64).astype(np.float64)
+
+
+def run(config) -> list[Path]:
+    """Create the observation files described by ``config``. Returns the written paths."""
+    t0 = time.perf_counter()
+    config = OmegaConf.to_container(config, resolve=True) if not isinstance(config, dict) else config
+
+    # ---- datasets: plain zarr paths, the first one is the reference grid -------------------
+    paths = []
+    for entry in config["datasets"]:
+        path = entry["dataset"] if isinstance(entry, dict) else entry
+        if not isinstance(path, str):
+            raise ValueError(
+                "bris-obs reads zarr stores directly: 'datasets' entries must be paths, not open_dataset recipes"
+            )
+        paths.append(path)
+    if not paths:
+        raise ValueError("config needs at least one entry in 'datasets'")
+
+    stores = {path: _open_zarr(path) for path in paths}
+    names = {path: list(stores[path].attrs["variables"]) for path in paths}
+    primary = stores[paths[0]]
+    lat = primary["latitudes"][:]
+    lon = primary["longitudes"][:]
+    dates = primary["dates"][:].astype("datetime64[s]")
+    for path in paths[1:]:
+        for key, ref in (("latitudes", lat), ("longitudes", lon), ("dates", dates)):
+            if not np.array_equal(stores[path][key][:].astype(ref.dtype), ref):
+                raise ValueError(f"dataset {path}: '{key}' differs from the first dataset {paths[0]}")
+
+    # ---- period ---------------------------------------------------------------------------
+    start = np.datetime64(str(config["start_date"]), "s")
+    end = np.datetime64(str(config["end_date"]), "s")
+    t_indices = np.flatnonzero((dates >= start) & (dates <= end))
+    if len(t_indices) == 0:
+        raise ValueError(f"no dates in [{start}, {end}]; dataset covers {dates[0]} .. {dates[-1]}")
+    LOGGER.info("%d timesteps: %s .. %s", len(t_indices), dates[t_indices[0]], dates[t_indices[-1]])
+
+    # ---- points ---------------------------------------------------------------------------
+    points_cfg = config.get("points") or {}
+    global_index, location_id = select_points(
+        lat, lon, points_cfg.get("area"), points_cfg.get("spacing"), points_cfg.get("every")
+    )
+    LOGGER.info("%d points selected (%s)", len(global_index), json.dumps(points_cfg))
+
+    # ---- read plan: which (store, variable) rows to read ------------------------------------
+    outputs = config["outputs"]
+    if not outputs:
+        raise ValueError("config needs at least one entry in 'outputs'")
+    needed = []  # source variable names, in row order
+    for out in outputs:
+        for var in DERIVED_VARIABLES.get(out["variable"], (out["variable"],)):
+            if var not in needed:
+                needed.append(var)
+    has_altitude = "z" in names[paths[0]]
+    if has_altitude and "z" not in needed:
+        needed.append("z")
+    if not has_altitude:
+        LOGGER.warning("Variable 'z' not in %s: altitudes set to 0", paths[0])
+
+    plan: dict[str, list[tuple[int, int]]] = {}
+    row_of = {}
+    for row, var in enumerate(needed):
+        for path in paths:
+            if var in names[path]:
+                plan.setdefault(path, []).append((row, names[path].index(var)))
+                row_of[var] = row
+                break
+        else:
+            raise ValueError(f"variable '{var}' not found in any dataset")
+
+    # ---- read ----------------------------------------------------------------------------------
+    jobs = [(int(t), plan, global_index) for t in t_indices]
+    values = np.full((len(t_indices), len(needed), len(global_index)), np.nan, dtype=np.float32)
+    position = {int(t): k for k, t in enumerate(t_indices)}
+    workers = int(config.get("workers", 1))
+    if workers > 1:
+        with Pool(workers, initializer=_worker_init, initargs=(paths,)) as pool:
+            results = pool.imap_unordered(_read_step, jobs, chunksize=4)
+            for k, (t_index, out) in enumerate(results):
+                values[position[t_index]] = out
+                if (k + 1) % 100 == 0 or k + 1 == len(jobs):
+                    LOGGER.info("read %d/%d timesteps (%.0f s)", k + 1, len(jobs), time.perf_counter() - t0)
+    else:
+        _worker_init(paths)
+        for k, job in enumerate(jobs):
+            t_index, out = _read_step(job)
+            values[position[t_index]] = out
+            if (k + 1) % 100 == 0 or k + 1 == len(jobs):
+                LOGGER.info("read %d/%d timesteps (%.0f s)", k + 1, len(jobs), time.perf_counter() - t0)
+
+    altitude = values[0, row_of["z"]] / GRAVITY if has_altitude else np.zeros(len(global_index), np.float32)
+    unixtime = _unixtime(dates[t_indices])
+    lon180 = _wrap_longitudes(lon[global_index])
+
+    # ---- write one Verif file per output ---------------------------------------------------------
+    import xarray as xr
+
+    provenance = {
+        "datasets": paths,
+        "points": points_cfg,
+        "start_date": str(dates[t_indices[0]]),
+        "end_date": str(dates[t_indices[-1]]),
+        "created": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    pattern = config["output"]
+    if "{name}" not in pattern and len(outputs) > 1:
+        raise ValueError("'output' must contain '{name}' when there is more than one output")
+
+    written = []
+    for out in outputs:
+        variable = out["variable"]
+        name = out.get("name", variable)
+        if variable in DERIVED_VARIABLES:
+            u, v = (values[:, row_of[c]] for c in DERIVED_VARIABLES[variable])
+            obs = np.sqrt(u**2 + v**2)
+        else:
+            obs = values[:, row_of[variable]]
+
+        from_units = anemoi_conventions.get_units(variable)
+        units = out.get("units", from_units)
+        if units is not None and from_units is not None and units != from_units:
+            obs, units = bris_units.convert(obs, from_units, units)
+        elif units is not None and from_units is None:
+            LOGGER.warning("%s: anemoi units unknown, writing values unchanged with units '%s'", variable, units)
+
+        cfname = cf.get_metadata(variable)["cfname"]
+        ds = xr.Dataset(
+            {
+                "obs": (("time", "location"), np.asarray(obs, dtype=np.float32)),
+                "lat": (("location",), lat[global_index].astype(np.float32)),
+                "lon": (("location",), lon180.astype(np.float32)),
+                "altitude": (("location",), np.asarray(altitude, dtype=np.float32)),
+            },
+            coords={"time": unixtime, "location": location_id.astype(np.int32)},
+            attrs={
+                "long_name": cfname,
+                "standard_name": cfname,
+                "Conventions": "verif_1.0.0",
+                "anemoi_variable": variable,
+                "provenance": json.dumps(provenance, default=str),
+                **({"units": units} if units is not None else {}),
+            },
+        )
+        ds["time"].attrs["units"] = "seconds since 1970-01-01 00:00:00 +00:00"
+
+        filename = Path(out.get("filename") or pattern.format(name=name))
+        filename.parent.mkdir(parents=True, exist_ok=True)
+        ds.to_netcdf(filename, encoding={"obs": {"zlib": True, "complevel": 4}})
+        LOGGER.info(
+            "%-10s %s  range %.3g .. %.3g %s  nan=%d",
+            name, filename, np.nanmin(obs), np.nanmax(obs), units or "", int(np.isnan(obs).sum()),
+        )
+        written.append(filename)
+
+    LOGGER.info("done in %.0f s", time.perf_counter() - t0)
+    return written
+
+
+def parse_args(arg_list: list[str] | None) -> dict:
+    parser = ArgumentParser(description="Create Verif observation files from anemoi-datasets zarr stores")
+    parser.add_argument("--config", type=str, required=True)
+    parser.add_argument("--debug", action="store_true")
+    parser.add_argument("-sd", type=str, dest="start_date", required=False)
+    parser.add_argument("-ed", type=str, dest="end_date", required=False)
+    parser.add_argument("-w", type=int, dest="workers", required=False)
+    args, _ = parser.parse_known_args(arg_list)
+    return {k: v for k, v in args.__dict__.items() if v is not None}
+
+
+def main(arg_list: list[str] | None = None) -> int:
+    args = parse_args(arg_list)
+    logging.basicConfig(
+        level=logging.DEBUG if args.pop("debug", False) else logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        stream=sys.stdout,
+    )
+    config = OmegaConf.load(args.pop("config"))
+    config = OmegaConf.merge(config, OmegaConf.create(args))
+    run(config)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bris/obs.py
+++ b/bris/obs.py
@@ -1,54 +1,11 @@
-"""Create Verif observation files from anemoi-datasets zarr stores.
-
-    bris-obs --config obs.yaml
-
-Extracts a set of grid points from an analysis dataset over a period and writes one
-Verif file per variable (dimensions ``time`` and ``location``), which the ``verif``
-observation source of the ``verif`` output can read. This makes it possible to verify
-forecasts against analyses at a subset of points without reading the full dataset at
-inference time.
-
-Example config::
-
-    start_date: 2023-01-01T00:00:00
-    end_date: 2023-12-31T18:00:00
-    output: /path/to/verification/{name}/analysis.nc   # {name} is replaced per output
-    workers: 16                                        # parallel readers (1 = in-process)
-
-    points:
-      area: [40, -25, -40, 55]   # N, W, S, E (optional, whole grid if omitted)
-      spacing: 2.5               # nearest grid point to each node of a regular lat/lon grid
-      # every: 1000              # alternative: every n-th grid point (index stride)
-
-    datasets:                    # zarr paths; the first defines grid, dates and altitudes (z)
-      - /path/to/analysis.zarr
-      - /path/to/analysis-extra-variables.zarr   # same grid and dates, e.g. cloud variables
-
-    outputs:
-      - {name: t2m, variable: 2t, units: degC}
-      - {name: mslp, variable: msl, units: hPa}
-      - {name: precip6h, variable: tp, units: mm}
-      - {name: ws10m, variable: ws}             # derived from 10u/10v; anemoi units kept
-      - {name: tcc, variable: tcc}
-
-The zarr stores are read directly (one chunk decompression per timestep and chunk of
-variables), which is orders of magnitude faster than going through
-``anemoi.datasets.open_dataset`` with an ``area`` crop for point subsets. Only plain zarr
-stores are supported for that reason, not open_dataset recipes.
-
-Point selection: ``spacing`` picks, for each node of a regular latitude/longitude grid
-over the area, the nearest dataset grid point (even coverage, every point is a real grid
-point). ``every`` keeps every n-th point in storage order; on reduced Gaussian grids this
-aliases with the row length and gives very uneven coverage, so ``spacing`` is preferred.
-The ``location`` id is the index of the point in the (area-cropped) grid.
-"""
+"""Create Verif observation files from anemoi-datasets zarr stores (bris-obs --config obs.yaml)."""
 
 import json
 import logging
 import sys
 import time
 from argparse import ArgumentParser
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from multiprocessing import Pool
 from pathlib import Path
 
@@ -108,7 +65,9 @@ def _wrap_longitudes(lon: np.ndarray) -> np.ndarray:
 
 def _xyz(lat_deg: np.ndarray, lon_deg: np.ndarray) -> np.ndarray:
     la, lo = np.deg2rad(lat_deg), np.deg2rad(lon_deg)
-    return np.column_stack([np.cos(la) * np.cos(lo), np.cos(la) * np.sin(lo), np.sin(la)])
+    return np.column_stack(
+        [np.cos(la) * np.cos(lo), np.cos(la) * np.sin(lo), np.sin(la)]
+    )
 
 
 def select_points(
@@ -191,13 +150,21 @@ def select_points(
 
 def _unixtime(dates: np.ndarray) -> np.ndarray:
     dates = np.asarray(dates).astype("datetime64[s]")
-    return (dates - np.datetime64("1970-01-01T00:00:00", "s")).astype(np.int64).astype(np.float64)
+    return (
+        (dates - np.datetime64("1970-01-01T00:00:00", "s"))
+        .astype(np.int64)
+        .astype(np.float64)
+    )
 
 
 def run(config) -> list[Path]:
     """Create the observation files described by ``config``. Returns the written paths."""
     t0 = time.perf_counter()
-    config = OmegaConf.to_container(config, resolve=True) if not isinstance(config, dict) else config
+    config = (
+        OmegaConf.to_container(config, resolve=True)
+        if not isinstance(config, dict)
+        else config
+    )
 
     # ---- datasets: plain zarr paths, the first one is the reference grid -------------------
     paths = []
@@ -220,20 +187,33 @@ def run(config) -> list[Path]:
     for path in paths[1:]:
         for key, ref in (("latitudes", lat), ("longitudes", lon), ("dates", dates)):
             if not np.array_equal(stores[path][key][:].astype(ref.dtype), ref):
-                raise ValueError(f"dataset {path}: '{key}' differs from the first dataset {paths[0]}")
+                raise ValueError(
+                    f"dataset {path}: '{key}' differs from the first dataset {paths[0]}"
+                )
 
     # ---- period ---------------------------------------------------------------------------
     start = np.datetime64(str(config["start_date"]), "s")
     end = np.datetime64(str(config["end_date"]), "s")
     t_indices = np.flatnonzero((dates >= start) & (dates <= end))
     if len(t_indices) == 0:
-        raise ValueError(f"no dates in [{start}, {end}]; dataset covers {dates[0]} .. {dates[-1]}")
-    LOGGER.info("%d timesteps: %s .. %s", len(t_indices), dates[t_indices[0]], dates[t_indices[-1]])
+        raise ValueError(
+            f"no dates in [{start}, {end}]; dataset covers {dates[0]} .. {dates[-1]}"
+        )
+    LOGGER.info(
+        "%d timesteps: %s .. %s",
+        len(t_indices),
+        dates[t_indices[0]],
+        dates[t_indices[-1]],
+    )
 
     # ---- points ---------------------------------------------------------------------------
     points_cfg = config.get("points") or {}
     global_index, location_id = select_points(
-        lat, lon, points_cfg.get("area"), points_cfg.get("spacing"), points_cfg.get("every")
+        lat,
+        lon,
+        points_cfg.get("area"),
+        points_cfg.get("spacing"),
+        points_cfg.get("every"),
     )
     LOGGER.info("%d points selected (%s)", len(global_index), json.dumps(points_cfg))
 
@@ -265,7 +245,9 @@ def run(config) -> list[Path]:
 
     # ---- read ----------------------------------------------------------------------------------
     jobs = [(int(t), plan, global_index) for t in t_indices]
-    values = np.full((len(t_indices), len(needed), len(global_index)), np.nan, dtype=np.float32)
+    values = np.full(
+        (len(t_indices), len(needed), len(global_index)), np.nan, dtype=np.float32
+    )
     position = {int(t): k for k, t in enumerate(t_indices)}
     workers = int(config.get("workers", 1))
     if workers > 1:
@@ -274,16 +256,30 @@ def run(config) -> list[Path]:
             for k, (t_index, out) in enumerate(results):
                 values[position[t_index]] = out
                 if (k + 1) % 100 == 0 or k + 1 == len(jobs):
-                    LOGGER.info("read %d/%d timesteps (%.0f s)", k + 1, len(jobs), time.perf_counter() - t0)
+                    LOGGER.info(
+                        "read %d/%d timesteps (%.0f s)",
+                        k + 1,
+                        len(jobs),
+                        time.perf_counter() - t0,
+                    )
     else:
         _worker_init(paths)
         for k, job in enumerate(jobs):
             t_index, out = _read_step(job)
             values[position[t_index]] = out
             if (k + 1) % 100 == 0 or k + 1 == len(jobs):
-                LOGGER.info("read %d/%d timesteps (%.0f s)", k + 1, len(jobs), time.perf_counter() - t0)
+                LOGGER.info(
+                    "read %d/%d timesteps (%.0f s)",
+                    k + 1,
+                    len(jobs),
+                    time.perf_counter() - t0,
+                )
 
-    altitude = values[0, row_of["z"]] / GRAVITY if has_altitude else np.zeros(len(global_index), np.float32)
+    altitude = (
+        values[0, row_of["z"]] / GRAVITY
+        if has_altitude
+        else np.zeros(len(global_index), np.float32)
+    )
     unixtime = _unixtime(dates[t_indices])
     lon180 = _wrap_longitudes(lon[global_index])
 
@@ -295,11 +291,13 @@ def run(config) -> list[Path]:
         "points": points_cfg,
         "start_date": str(dates[t_indices[0]]),
         "end_date": str(dates[t_indices[-1]]),
-        "created": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "created": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
     pattern = config["output"]
     if "{name}" not in pattern and len(outputs) > 1:
-        raise ValueError("'output' must contain '{name}' when there is more than one output")
+        raise ValueError(
+            "'output' must contain '{name}' when there is more than one output"
+        )
 
     written = []
     for out in outputs:
@@ -316,7 +314,11 @@ def run(config) -> list[Path]:
         if units is not None and from_units is not None and units != from_units:
             obs, units = bris_units.convert(obs, from_units, units)
         elif units is not None and from_units is None:
-            LOGGER.warning("%s: anemoi units unknown, writing values unchanged with units '%s'", variable, units)
+            LOGGER.warning(
+                "%s: anemoi units unknown, writing values unchanged with units '%s'",
+                variable,
+                units,
+            )
 
         cfname = cf.get_metadata(variable)["cfname"]
         ds = xr.Dataset(
@@ -343,7 +345,12 @@ def run(config) -> list[Path]:
         ds.to_netcdf(filename, encoding={"obs": {"zlib": True, "complevel": 4}})
         LOGGER.info(
             "%-10s %s  range %.3g .. %.3g %s  nan=%d",
-            name, filename, np.nanmin(obs), np.nanmax(obs), units or "", int(np.isnan(obs).sum()),
+            name,
+            filename,
+            np.nanmin(obs),
+            np.nanmax(obs),
+            units or "",
+            int(np.isnan(obs).sum()),
         )
         written.append(filename)
 
@@ -352,7 +359,9 @@ def run(config) -> list[Path]:
 
 
 def parse_args(arg_list: list[str] | None) -> dict:
-    parser = ArgumentParser(description="Create Verif observation files from anemoi-datasets zarr stores")
+    parser = ArgumentParser(
+        description="Create Verif observation files from anemoi-datasets zarr stores"
+    )
     parser.add_argument("--config", type=str, required=True)
     parser.add_argument("--debug", action="store_true")
     parser.add_argument("-sd", type=str, dest="start_date", required=False)

--- a/bris/obs.py
+++ b/bris/obs.py
@@ -157,6 +157,79 @@ def _unixtime(dates: np.ndarray) -> np.ndarray:
     )
 
 
+RECIPE_KEYS = {
+    "dataset",
+    "join",
+    "area",
+    "start",
+    "end",
+    "every_loc",
+    "every",
+    "spacing",
+}
+
+
+def parse_recipe(recipe) -> dict:
+    """Parse an open_dataset-like recipe into zarr paths and point-selection options.
+
+    Supported: a zarr path, ``{dataset: <recipe>}``, ``{join: [<recipe>, ...]}`` (stores on the
+    same grid and dates), and the options ``area`` [N, W, S, E], ``start``, ``end``,
+    ``every_loc`` (index stride) and ``spacing`` (degrees), at any level. Other open_dataset
+    operations are not supported, since the stores are read directly.
+    """
+    result = {
+        "paths": [],
+        "area": None,
+        "start": None,
+        "end": None,
+        "every": None,
+        "spacing": None,
+    }
+
+    def merge(key, value):
+        if value is None:
+            return
+        if result[key] is not None and result[key] != value:
+            raise ValueError(
+                f"recipe: conflicting values for '{key}': {result[key]} and {value}"
+            )
+        result[key] = value
+
+    def walk(node):
+        if isinstance(node, str):
+            result["paths"].append(node)
+            return
+        if not isinstance(node, dict):
+            raise ValueError(
+                f"recipe: expected a path or a mapping, got {type(node).__name__}"
+            )
+        unknown = set(node) - RECIPE_KEYS
+        if unknown:
+            raise ValueError(
+                f"recipe: unsupported keys {sorted(unknown)}; bris-obs reads zarr stores directly and "
+                f"supports only {sorted(RECIPE_KEYS)}"
+            )
+        if "dataset" in node and "join" in node:
+            raise ValueError("recipe: give either 'dataset' or 'join', not both")
+        if "dataset" in node:
+            walk(node["dataset"])
+        elif "join" in node:
+            for member in node["join"]:
+                walk(member)
+        merge("area", node.get("area"))
+        merge("start", node.get("start"))
+        merge("end", node.get("end"))
+        merge("every", node.get("every_loc", node.get("every")))
+        merge("spacing", node.get("spacing"))
+
+    walk(recipe)
+    if not result["paths"]:
+        raise ValueError("recipe: no dataset path found")
+    if result["every"] is not None and result["spacing"] is not None:
+        raise ValueError("recipe: give either 'every_loc' or 'spacing', not both")
+    return result
+
+
 def run(config) -> list[Path]:
     """Create the observation files described by ``config``. Returns the written paths."""
     t0 = time.perf_counter()
@@ -166,18 +239,9 @@ def run(config) -> list[Path]:
         else config
     )
 
-    # ---- datasets: plain zarr paths, the first one is the reference grid -------------------
-    paths = []
-    for entry in config["datasets"]:
-        path = entry["dataset"] if isinstance(entry, dict) else entry
-        if not isinstance(path, str):
-            raise ValueError(
-                "bris-obs reads zarr stores directly: 'datasets' entries must be paths, not open_dataset recipes"
-            )
-        paths.append(path)
-    if not paths:
-        raise ValueError("config needs at least one entry in 'datasets'")
-
+    # ---- dataset recipe: zarr paths, the first one is the reference grid -------------------
+    recipe = parse_recipe(config["dataset"])
+    paths = recipe["paths"]
     stores = {path: _open_zarr(path) for path in paths}
     names = {path: list(stores[path].attrs["variables"]) for path in paths}
     primary = stores[paths[0]]
@@ -191,9 +255,15 @@ def run(config) -> list[Path]:
                     f"dataset {path}: '{key}' differs from the first dataset {paths[0]}"
                 )
 
-    # ---- period ---------------------------------------------------------------------------
-    start = np.datetime64(str(config["start_date"]), "s")
-    end = np.datetime64(str(config["end_date"]), "s")
+    # ---- period: recipe start/end, else the config's start_date/end_date ------------------
+    start = recipe["start"] or config.get("start_date")
+    end = recipe["end"] or config.get("end_date")
+    if start is None or end is None:
+        raise ValueError(
+            "period not set: give start_date/end_date or start/end in the dataset recipe"
+        )
+    start = np.datetime64(str(start), "s")
+    end = np.datetime64(str(end), "s")
     t_indices = np.flatnonzero((dates >= start) & (dates <= end))
     if len(t_indices) == 0:
         raise ValueError(
@@ -207,20 +277,30 @@ def run(config) -> list[Path]:
     )
 
     # ---- points ---------------------------------------------------------------------------
-    points_cfg = config.get("points") or {}
     global_index, location_id = select_points(
-        lat,
-        lon,
-        points_cfg.get("area"),
-        points_cfg.get("spacing"),
-        points_cfg.get("every"),
+        lat, lon, recipe["area"], recipe["spacing"], recipe["every"]
     )
-    LOGGER.info("%d points selected (%s)", len(global_index), json.dumps(points_cfg))
+    LOGGER.info(
+        "%d points selected (area=%s spacing=%s every=%s)",
+        len(global_index),
+        recipe["area"],
+        recipe["spacing"],
+        recipe["every"],
+    )
 
-    # ---- read plan: which (store, variable) rows to read ------------------------------------
-    outputs = config["outputs"]
+    # ---- outputs: verif entries like in the bris verif output ---------------------------------
+    outputs = []
+    for entry in config.get("outputs") or []:
+        out = entry.get("verif", entry) if isinstance(entry, dict) else None
+        if not out or "filename" not in out or "variable" not in out:
+            raise ValueError(
+                "each output must be a 'verif' entry with 'filename' and 'variable'"
+            )
+        outputs.append(out)
     if not outputs:
         raise ValueError("config needs at least one entry in 'outputs'")
+
+    # ---- read plan: which (store, variable) rows to read ------------------------------------
     needed = []  # source variable names, in row order
     for out in outputs:
         for var in DERIVED_VARIABLES.get(out["variable"], (out["variable"],)):
@@ -287,22 +367,15 @@ def run(config) -> list[Path]:
     import xarray as xr
 
     provenance = {
-        "datasets": paths,
-        "points": points_cfg,
+        "dataset": config["dataset"],
         "start_date": str(dates[t_indices[0]]),
         "end_date": str(dates[t_indices[-1]]),
         "created": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
-    pattern = config["output"]
-    if "{name}" not in pattern and len(outputs) > 1:
-        raise ValueError(
-            "'output' must contain '{name}' when there is more than one output"
-        )
 
     written = []
     for out in outputs:
         variable = out["variable"]
-        name = out.get("name", variable)
         if variable in DERIVED_VARIABLES:
             u, v = (values[:, row_of[c]] for c in DERIVED_VARIABLES[variable])
             obs = np.sqrt(u**2 + v**2)
@@ -340,12 +413,12 @@ def run(config) -> list[Path]:
         )
         ds["time"].attrs["units"] = "seconds since 1970-01-01 00:00:00 +00:00"
 
-        filename = Path(out.get("filename") or pattern.format(name=name))
+        filename = Path(out["filename"])
         filename.parent.mkdir(parents=True, exist_ok=True)
         ds.to_netcdf(filename, encoding={"obs": {"zlib": True, "complevel": 4}})
         LOGGER.info(
-            "%-10s %s  range %.3g .. %.3g %s  nan=%d",
-            name,
+            "%-6s %s  range %.3g .. %.3g %s  nan=%d",
+            variable,
             filename,
             np.nanmin(obs),
             np.nanmax(obs),

--- a/bris/utils.py
+++ b/bris/utils.py
@@ -124,8 +124,10 @@ def create_config(config_path: str, overrides: dict) -> DictConfig | ListConfig:
     ]
     # Dotted keys (e.g. "checkpoints.forecaster.leadtimes" from -l) must become nested
     # entries; OmegaConf.create would keep them as one flat key that overrides nothing.
-    dotlist = [f"{key}={value}" for key, value in overrides.items()]
-    return OmegaConf.merge(config, OmegaConf.from_dotlist(dotlist))
+    # OmegaConf.update keeps the values' Python types (no YAML re-parsing of strings).
+    for key, value in overrides.items():
+        OmegaConf.update(config, key, value, merge=True)
+    return config
 
 
 def setup_logging(config: DotDict) -> None:

--- a/bris/utils.py
+++ b/bris/utils.py
@@ -122,7 +122,10 @@ def create_config(config_path: str, overrides: dict) -> DictConfig | ListConfig:
         {"override hydra/hydra_logging": "none"},  # disable config parsing logs
         "_self_",
     ]
-    return OmegaConf.merge(config, OmegaConf.create(overrides))
+    # Dotted keys (e.g. "checkpoints.forecaster.leadtimes" from -l) must become nested
+    # entries; OmegaConf.create would keep them as one flat key that overrides nothing.
+    dotlist = [f"{key}={value}" for key, value in overrides.items()]
+    return OmegaConf.merge(config, OmegaConf.from_dotlist(dotlist))
 
 
 def setup_logging(config: DotDict) -> None:

--- a/config/verif_obs_template.yaml
+++ b/config/verif_obs_template.yaml
@@ -7,7 +7,8 @@ workers: 16
 
 # open_dataset-style recipe, as for the anemoidataset obs source. The zarr stores are read
 # directly, so only these keys are supported: dataset, join (stores on the same grid and
-# dates), area [N, W, S, E], start/end, and one of every_loc (index stride) or spacing
+# dates), area [N, W, S, E], start/end, frequency (e.g. 6h to subsample an hourly dataset;
+# default: the dataset's own step), and one of every_loc (index stride) or spacing
 # (degrees: nearest grid point to each node of a regular lat/lon grid, even coverage).
 dataset:
   dataset:
@@ -16,6 +17,7 @@ dataset:
       - dataset: /PATH/TO/analysis-extra-variables.zarr   # e.g. cloud variables
   area: [40, -25, -40, 55]
   spacing: 2.5  # degrees
+  # frequency: 6h
   # every_loc: 1000
 
 # One Verif file per entry, like the verif output: filename, variable, units (anemoi units if omitted)

--- a/config/verif_obs_template.yaml
+++ b/config/verif_obs_template.yaml
@@ -3,27 +3,38 @@
 # for use as obs_sources (verif) in the verif output of a bris inference config.
 start_date: 2023-01-01T00:00:00
 end_date: 2023-12-31T18:00:00
-
-# {name} is replaced by each output's name
-output: /PATH/TO/verification/{name}/analysis.nc
 workers: 16
 
-points:
-  area: [40, -25, -40, 55]   # N, W, S, E; omit for the whole grid
-  spacing: 2.5               # nearest grid point to each node of a 2.5 degree lat/lon grid
-  # every: 1000              # or every n-th point (uneven on reduced Gaussian grids)
+# open_dataset-style recipe, as for the anemoidataset obs source. The zarr stores are read
+# directly, so only these keys are supported: dataset, join (stores on the same grid and
+# dates), area [N, W, S, E], start/end, and one of every_loc (index stride) or spacing
+# (degrees: nearest grid point to each node of a regular lat/lon grid, even coverage).
+dataset:
+  dataset:
+    join:
+      - dataset: /PATH/TO/analysis.zarr
+      - dataset: /PATH/TO/analysis-extra-variables.zarr   # e.g. cloud variables
+  area: [40, -25, -40, 55]
+  spacing: 2.5
+  # every_loc: 1000
 
-# Plain zarr stores (no open_dataset recipes). The first defines grid, dates and altitudes (z);
-# further stores may supply variables missing from the first (same grid and dates required).
-datasets:
-  - /PATH/TO/analysis.zarr
-  # - /PATH/TO/analysis-extra-variables.zarr
-
+# One Verif file per entry, like the verif output: filename, variable, units (anemoi units if omitted)
 outputs:
-  - {name: t2m, variable: 2t, units: degC}
-  - {name: mslp, variable: msl, units: hPa}
-  - {name: precip6h, variable: tp, units: mm}
-  - {name: ws10m, variable: ws}          # derived from 10u/10v
-  - {name: t850, variable: t_850}
-  - {name: z500, variable: z_500}
-  - {name: tcc, variable: tcc}
+  - verif:
+      filename: /PATH/TO/verification/t2m/analysis.nc
+      variable: 2t
+      units: degC
+  - verif:
+      filename: /PATH/TO/verification/mslp/analysis.nc
+      variable: msl
+      units: hPa
+  - verif:
+      filename: /PATH/TO/verification/precip6h/analysis.nc
+      variable: tp
+      units: mm
+  - verif:
+      filename: /PATH/TO/verification/ws10m/analysis.nc
+      variable: ws          # derived from 10u/10v
+  - verif:
+      filename: /PATH/TO/verification/tcc/analysis.nc
+      variable: tcc

--- a/config/verif_obs_template.yaml
+++ b/config/verif_obs_template.yaml
@@ -1,0 +1,29 @@
+# bris-obs --config verif_obs_template.yaml
+# Extract analysis "observations" at a subset of points into Verif files, one per variable,
+# for use as obs_sources (verif) in the verif output of a bris inference config.
+start_date: 2023-01-01T00:00:00
+end_date: 2023-12-31T18:00:00
+
+# {name} is replaced by each output's name
+output: /PATH/TO/verification/{name}/analysis.nc
+workers: 16
+
+points:
+  area: [40, -25, -40, 55]   # N, W, S, E; omit for the whole grid
+  spacing: 2.5               # nearest grid point to each node of a 2.5 degree lat/lon grid
+  # every: 1000              # or every n-th point (uneven on reduced Gaussian grids)
+
+# Plain zarr stores (no open_dataset recipes). The first defines grid, dates and altitudes (z);
+# further stores may supply variables missing from the first (same grid and dates required).
+datasets:
+  - /PATH/TO/analysis.zarr
+  # - /PATH/TO/analysis-extra-variables.zarr
+
+outputs:
+  - {name: t2m, variable: 2t, units: degC}
+  - {name: mslp, variable: msl, units: hPa}
+  - {name: precip6h, variable: tp, units: mm}
+  - {name: ws10m, variable: ws}          # derived from 10u/10v
+  - {name: t850, variable: t_850}
+  - {name: z500, variable: z_500}
+  - {name: tcc, variable: tcc}

--- a/config/verif_obs_template.yaml
+++ b/config/verif_obs_template.yaml
@@ -15,7 +15,7 @@ dataset:
       - dataset: /PATH/TO/analysis.zarr
       - dataset: /PATH/TO/analysis-extra-variables.zarr   # e.g. cloud variables
   area: [40, -25, -40, 55]
-  spacing: 2.5
+  spacing: 2.5  # degrees
   # every_loc: 1000
 
 # One Verif file per entry, like the verif output: filename, variable, units (anemoi units if omitted)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ urls.Repository = "https://github.com/metno/bris-inference/"
 [project.scripts]
 bris = "bris:main"
 bris-inspect = "bris.inspect:main"
+bris-obs = "bris.obs:main"
 
 [tool.setuptools]
 include-package-data = true

--- a/tests/test_obs.py
+++ b/tests/test_obs.py
@@ -9,7 +9,11 @@ from bris import obs, sources
 def _make_zarr(path, variables, lat, lon, dates, values):
     """Write a minimal anemoi-datasets-like zarr store."""
     z = zarr.open(str(path), mode="w")
-    z.create_dataset("data", data=values.astype(np.float32), chunks=(1, values.shape[1], 1, values.shape[3]))
+    z.create_dataset(
+        "data",
+        data=values.astype(np.float32),
+        chunks=(1, values.shape[1], 1, values.shape[3]),
+    )
     z.create_dataset("latitudes", data=lat.astype(np.float64))
     z.create_dataset("longitudes", data=lon.astype(np.float64))
     z.create_dataset("dates", data=dates.astype("datetime64[s]"))
@@ -19,7 +23,9 @@ def _make_zarr(path, variables, lat, lon, dates, values):
 
 @pytest.fixture
 def grid():
-    lat, lon = np.meshgrid(np.arange(-10, 10.01, 1.0), np.arange(0, 20.01, 1.0), indexing="ij")
+    lat, lon = np.meshgrid(
+        np.arange(-10, 10.01, 1.0), np.arange(0, 20.01, 1.0), indexing="ij"
+    )
     return lat.ravel(), lon.ravel()
 
 
@@ -27,7 +33,10 @@ def grid():
 def stores(tmp_path, grid):
     lat, lon = grid
     n = len(lat)
-    dates = np.array(["2023-01-01T00", "2023-01-01T06", "2023-01-01T12", "2023-01-01T18"], dtype="datetime64[s]")
+    dates = np.array(
+        ["2023-01-01T00", "2023-01-01T06", "2023-01-01T12", "2023-01-01T18"],
+        dtype="datetime64[s]",
+    )
     idx = np.arange(n, dtype=np.float32)
     t = np.arange(len(dates), dtype=np.float32)[:, None]
     main_vars = ["2t", "10u", "10v", "tp", "z"]
@@ -52,7 +61,9 @@ def stores(tmp_path, grid):
 
 def test_select_points_spacing(grid):
     lat, lon = grid
-    global_index, location_id = obs.select_points(lat, lon, area=[5, 2, -5, 12], spacing=2.5)
+    global_index, location_id = obs.select_points(
+        lat, lon, area=[5, 2, -5, 12], spacing=2.5
+    )
     assert len(global_index) == 25  # 5 x 5 target nodes, all distinct nearest points
     assert len(np.unique(location_id)) == 25
     assert np.all(lat[global_index] <= 5) and np.all(lat[global_index] >= -5)
@@ -114,31 +125,49 @@ def test_run_writes_verif_files(tmp_path, stores):
     lon = np.array([loc.lon for loc in locations])
     gi = (np.round(lat + 10) * 21 + np.round(lon)).astype(int)
     np.testing.assert_allclose(data, 273.15 + 0.01 * gi + 1.0 - 273.15, atol=1e-3)
-    np.testing.assert_allclose([loc.elev for loc in locations], 100.0 * (gi % 7), atol=1e-3)
+    np.testing.assert_allclose(
+        [loc.elev for loc in locations], 100.0 * (gi % 7), atol=1e-3
+    )
 
     tp = sources.Verif(str(tmp_path / "out" / "precip6h" / "analysis.nc"))
     assert tp.units == "mm"
-    np.testing.assert_allclose(tp.get("tp", start, start, 3600).get_data("tp", start), 1.0 * (gi % 5), atol=1e-3)
+    np.testing.assert_allclose(
+        tp.get("tp", start, start, 3600).get_data("tp", start),
+        1.0 * (gi % 5),
+        atol=1e-3,
+    )
 
     ws = sources.Verif(str(tmp_path / "out" / "ws10m" / "analysis.nc"))
     assert ws.units == "m/s"
-    np.testing.assert_allclose(ws.get("ws", start, start, 3600).get_data("ws", start), np.hypot(4.0, 4.0), atol=1e-3)
+    np.testing.assert_allclose(
+        ws.get("ws", start, start, 3600).get_data("ws", start),
+        np.hypot(4.0, 4.0),
+        atol=1e-3,
+    )
 
     tcc = sources.Verif(str(tmp_path / "out" / "tcc" / "analysis.nc"))
-    np.testing.assert_allclose(tcc.get("tcc", start, start, 3600).get_data("tcc", start), 0.6, atol=1e-3)
+    np.testing.assert_allclose(
+        tcc.get("tcc", start, start, 3600).get_data("tcc", start), 0.6, atol=1e-3
+    )
     assert len(tcc.file["time"]) == 3
 
 
 def test_run_rejects_mismatched_grid(tmp_path, stores, grid):
     lat, lon = grid
     other = _make_zarr(
-        tmp_path / "other.zarr", ["tcc"], lat + 1.0, lon, stores["dates"],
+        tmp_path / "other.zarr",
+        ["tcc"],
+        lat + 1.0,
+        lon,
+        stores["dates"],
         np.zeros((len(stores["dates"]), 1, 1, len(lat)), np.float32),
     )
     config = OmegaConf.create(
         {
-            "start_date": "2023-01-01T00:00:00", "end_date": "2023-01-01T18:00:00",
-            "output": str(tmp_path / "{name}.nc"), "datasets": [stores["main"], other],
+            "start_date": "2023-01-01T00:00:00",
+            "end_date": "2023-01-01T18:00:00",
+            "output": str(tmp_path / "{name}.nc"),
+            "datasets": [stores["main"], other],
             "outputs": [{"name": "tcc", "variable": "tcc"}],
         }
     )

--- a/tests/test_obs.py
+++ b/tests/test_obs.py
@@ -91,20 +91,60 @@ def test_select_points_errors(grid):
         obs.select_points(lat, lon, spacing=1.0, every=2)
 
 
+def _verif(filename, variable, units=None):
+    entry = {"filename": str(filename), "variable": variable}
+    if units:
+        entry["units"] = units
+    return {"verif": entry}
+
+
+def test_parse_recipe():
+    r = obs.parse_recipe("/a.zarr")
+    assert r["paths"] == ["/a.zarr"] and r["area"] is None
+    r = obs.parse_recipe(
+        {
+            "dataset": {"join": [{"dataset": "/a.zarr"}, "/b.zarr"]},
+            "area": [5, 2, -5, 12],
+            "every_loc": 10,
+            "start": "2023-01-01",
+        }
+    )
+    assert r["paths"] == ["/a.zarr", "/b.zarr"]
+    assert (
+        r["area"] == [5, 2, -5, 12] and r["every"] == 10 and r["start"] == "2023-01-01"
+    )
+    with pytest.raises(ValueError, match="unsupported keys"):
+        obs.parse_recipe({"dataset": "/a.zarr", "select": ["2t"]})
+    with pytest.raises(ValueError, match="conflicting"):
+        obs.parse_recipe(
+            {
+                "dataset": {"dataset": "/a.zarr", "area": [1, 0, 0, 1]},
+                "area": [2, 0, 0, 2],
+            }
+        )
+    with pytest.raises(ValueError, match="either"):
+        obs.parse_recipe({"dataset": "/a.zarr", "every_loc": 2, "spacing": 1.0})
+
+
 def test_run_writes_verif_files(tmp_path, stores):
+    out = tmp_path / "out"
     config = OmegaConf.create(
         {
             "start_date": "2023-01-01T06:00:00",
             "end_date": "2023-01-01T18:00:00",
-            "output": str(tmp_path / "out" / "{name}" / "analysis.nc"),
             "workers": 1,
-            "points": {"area": [5, 2, -5, 12], "spacing": 2.5},
-            "datasets": [stores["main"], stores["extra"]],
+            "dataset": {
+                "dataset": {
+                    "join": [{"dataset": stores["main"]}, {"dataset": stores["extra"]}]
+                },
+                "area": [5, 2, -5, 12],
+                "spacing": 2.5,
+            },
             "outputs": [
-                {"name": "t2m", "variable": "2t", "units": "degC"},
-                {"name": "precip6h", "variable": "tp", "units": "mm"},
-                {"name": "ws10m", "variable": "ws"},
-                {"name": "tcc", "variable": "tcc"},
+                _verif(out / "t2m" / "analysis.nc", "2t", "degC"),
+                _verif(out / "precip6h" / "analysis.nc", "tp", "mm"),
+                _verif(out / "ws10m" / "analysis.nc", "ws"),
+                _verif(out / "tcc" / "analysis.nc", "tcc"),
             ],
         }
     )
@@ -113,7 +153,7 @@ def test_run_writes_verif_files(tmp_path, stores):
     assert {p.parent.name for p in written} == {"t2m", "precip6h", "ws10m", "tcc"}
 
     # Readable by the bris verif source, with the expected values and units
-    src = sources.Verif(str(tmp_path / "out" / "t2m" / "analysis.nc"))
+    src = sources.Verif(str(out / "t2m" / "analysis.nc"))
     locations = src.locations
     assert len(locations) == 25
     assert src.units == "degC"
@@ -129,7 +169,7 @@ def test_run_writes_verif_files(tmp_path, stores):
         [loc.elev for loc in locations], 100.0 * (gi % 7), atol=1e-3
     )
 
-    tp = sources.Verif(str(tmp_path / "out" / "precip6h" / "analysis.nc"))
+    tp = sources.Verif(str(out / "precip6h" / "analysis.nc"))
     assert tp.units == "mm"
     np.testing.assert_allclose(
         tp.get("tp", start, start, 3600).get_data("tp", start),
@@ -137,7 +177,7 @@ def test_run_writes_verif_files(tmp_path, stores):
         atol=1e-3,
     )
 
-    ws = sources.Verif(str(tmp_path / "out" / "ws10m" / "analysis.nc"))
+    ws = sources.Verif(str(out / "ws10m" / "analysis.nc"))
     assert ws.units == "m/s"
     np.testing.assert_allclose(
         ws.get("ws", start, start, 3600).get_data("ws", start),
@@ -145,7 +185,7 @@ def test_run_writes_verif_files(tmp_path, stores):
         atol=1e-3,
     )
 
-    tcc = sources.Verif(str(tmp_path / "out" / "tcc" / "analysis.nc"))
+    tcc = sources.Verif(str(out / "tcc" / "analysis.nc"))
     np.testing.assert_allclose(
         tcc.get("tcc", start, start, 3600).get_data("tcc", start), 0.6, atol=1e-3
     )
@@ -166,9 +206,8 @@ def test_run_rejects_mismatched_grid(tmp_path, stores, grid):
         {
             "start_date": "2023-01-01T00:00:00",
             "end_date": "2023-01-01T18:00:00",
-            "output": str(tmp_path / "{name}.nc"),
-            "datasets": [stores["main"], other],
-            "outputs": [{"name": "tcc", "variable": "tcc"}],
+            "dataset": {"join": [stores["main"], other]},
+            "outputs": [_verif(tmp_path / "tcc.nc", "tcc")],
         }
     )
     with pytest.raises(ValueError, match="latitudes"):
@@ -180,17 +219,34 @@ def test_main_cli(tmp_path, stores):
     OmegaConf.save(
         OmegaConf.create(
             {
+                "dataset": {
+                    "dataset": stores["main"],
+                    "start": "2023-01-01T00:00:00",
+                    "end": "2023-01-01T18:00:00",
+                    "every_loc": 50,
+                },
+                "outputs": [_verif(tmp_path / "cli" / "t2m.nc", "2t", "degC")],
+            }
+        ),
+        cfg,
+    )
+    assert obs.main(["--config", str(cfg)]) == 0
+    src = sources.Verif(str(tmp_path / "cli" / "t2m.nc"))
+    assert len(src.file["time"]) == 4  # period from the recipe's start/end
+    assert len(src.locations) == stores["n"] // 50 + 1
+
+    # top-level start_date/end_date apply when the recipe has none; -sd overrides them
+    OmegaConf.save(
+        OmegaConf.create(
+            {
                 "start_date": "2023-01-01T00:00:00",
                 "end_date": "2023-01-01T18:00:00",
-                "output": str(tmp_path / "cli" / "{name}.nc"),
-                "points": {"every": 50},
-                "datasets": [stores["main"]],
-                "outputs": [{"name": "t2m", "variable": "2t", "units": "degC"}],
+                "dataset": {"dataset": stores["main"], "every_loc": 50},
+                "outputs": [_verif(tmp_path / "cli2" / "t2m.nc", "2t", "degC")],
             }
         ),
         cfg,
     )
     assert obs.main(["--config", str(cfg), "-sd", "2023-01-01T12:00:00"]) == 0
-    src = sources.Verif(str(tmp_path / "cli" / "t2m.nc"))
-    assert len(src.file["time"]) == 2  # start override applied: 12 and 18 UTC
-    assert len(src.locations) == stores["n"] // 50 + 1
+    src = sources.Verif(str(tmp_path / "cli2" / "t2m.nc"))
+    assert len(src.file["time"]) == 2

--- a/tests/test_obs.py
+++ b/tests/test_obs.py
@@ -192,6 +192,35 @@ def test_run_writes_verif_files(tmp_path, stores):
     assert len(tcc.file["time"]) == 3
 
 
+def test_frequency_subsamples_dates(tmp_path, grid):
+    lat, lon = grid
+    dates = np.arange("2023-01-01T00", "2023-01-01T13", dtype="datetime64[h]").astype(
+        "datetime64[s]"
+    )  # 13 hourly steps
+    values = (
+        np.zeros((len(dates), 1, 1, len(lat)), np.float32)
+        + np.arange(len(dates), dtype=np.float32)[:, None, None, None]
+    )
+    store = _make_zarr(tmp_path / "hourly.zarr", ["2t"], lat, lon, dates, values)
+
+    def run(**extra):
+        config = OmegaConf.create(
+            {
+                "dataset": {"dataset": store, "every_loc": 50, **extra},
+                "outputs": [_verif(tmp_path / "freq" / "t2m.nc", "2t")],
+            }
+        )
+        obs.run(config)
+        return sources.Verif(str(tmp_path / "freq" / "t2m.nc")).file["time"].values
+
+    assert len(run()) == 13  # default: the dataset's own hourly step
+    times = run(frequency="6h")
+    assert len(times) == 3 and np.all(np.diff(times) == 6 * 3600)
+    assert len(run(frequency="6h", start="2023-01-01T02:00:00")) == 2  # 02 and 08 UTC
+    with pytest.raises(ValueError, match="not a multiple"):
+        run(frequency="90m")
+
+
 def test_run_rejects_mismatched_grid(tmp_path, stores, grid):
     lat, lon = grid
     other = _make_zarr(

--- a/tests/test_obs.py
+++ b/tests/test_obs.py
@@ -1,0 +1,167 @@
+import numpy as np
+import pytest
+import zarr
+from omegaconf import OmegaConf
+
+from bris import obs, sources
+
+
+def _make_zarr(path, variables, lat, lon, dates, values):
+    """Write a minimal anemoi-datasets-like zarr store."""
+    z = zarr.open(str(path), mode="w")
+    z.create_dataset("data", data=values.astype(np.float32), chunks=(1, values.shape[1], 1, values.shape[3]))
+    z.create_dataset("latitudes", data=lat.astype(np.float64))
+    z.create_dataset("longitudes", data=lon.astype(np.float64))
+    z.create_dataset("dates", data=dates.astype("datetime64[s]"))
+    z.attrs["variables"] = list(variables)
+    return str(path)
+
+
+@pytest.fixture
+def grid():
+    lat, lon = np.meshgrid(np.arange(-10, 10.01, 1.0), np.arange(0, 20.01, 1.0), indexing="ij")
+    return lat.ravel(), lon.ravel()
+
+
+@pytest.fixture
+def stores(tmp_path, grid):
+    lat, lon = grid
+    n = len(lat)
+    dates = np.array(["2023-01-01T00", "2023-01-01T06", "2023-01-01T12", "2023-01-01T18"], dtype="datetime64[s]")
+    idx = np.arange(n, dtype=np.float32)
+    t = np.arange(len(dates), dtype=np.float32)[:, None]
+    main_vars = ["2t", "10u", "10v", "tp", "z"]
+    main = np.stack(
+        [
+            273.15 + 0.01 * idx + t,  # 2t [K]
+            3.0 + 0 * idx + t,  # 10u
+            4.0 + 0 * idx + 0 * t,  # 10v
+            0.001 * (idx % 5) + 0 * t,  # tp [m]
+            9.81 * 100.0 * (idx % 7) + 0 * t,  # z -> altitude 0..600 m
+        ],
+        axis=1,
+    )[:, :, None, :]
+    extra = (0.5 + 0 * idx + 0.1 * t)[:, None, None, :]  # tcc
+    return {
+        "main": _make_zarr(tmp_path / "main.zarr", main_vars, lat, lon, dates, main),
+        "extra": _make_zarr(tmp_path / "extra.zarr", ["tcc"], lat, lon, dates, extra),
+        "n": n,
+        "dates": dates,
+    }
+
+
+def test_select_points_spacing(grid):
+    lat, lon = grid
+    global_index, location_id = obs.select_points(lat, lon, area=[5, 2, -5, 12], spacing=2.5)
+    assert len(global_index) == 25  # 5 x 5 target nodes, all distinct nearest points
+    assert len(np.unique(location_id)) == 25
+    assert np.all(lat[global_index] <= 5) and np.all(lat[global_index] >= -5)
+    assert np.all(lon[global_index] >= 2) and np.all(lon[global_index] <= 12)
+
+
+def test_select_points_every(grid):
+    lat, lon = grid
+    global_index, location_id = obs.select_points(lat, lon, area=None, every=10)
+    assert len(global_index) == len(lat) // 10 + (1 if len(lat) % 10 else 0)
+    np.testing.assert_array_equal(global_index, location_id)  # no crop: same indexing
+
+
+def test_select_points_all(grid):
+    lat, lon = grid
+    global_index, _ = obs.select_points(lat, lon, area=[1, 0, 0, 1])
+    assert len(global_index) == 4
+
+
+def test_select_points_errors(grid):
+    lat, lon = grid
+    with pytest.raises(ValueError):
+        obs.select_points(lat, lon, area=[0, 0, 5, 5])  # N <= S
+    with pytest.raises(ValueError):
+        obs.select_points(lat, lon, spacing=1.0, every=2)
+
+
+def test_run_writes_verif_files(tmp_path, stores):
+    config = OmegaConf.create(
+        {
+            "start_date": "2023-01-01T06:00:00",
+            "end_date": "2023-01-01T18:00:00",
+            "output": str(tmp_path / "out" / "{name}" / "analysis.nc"),
+            "workers": 1,
+            "points": {"area": [5, 2, -5, 12], "spacing": 2.5},
+            "datasets": [stores["main"], stores["extra"]],
+            "outputs": [
+                {"name": "t2m", "variable": "2t", "units": "degC"},
+                {"name": "precip6h", "variable": "tp", "units": "mm"},
+                {"name": "ws10m", "variable": "ws"},
+                {"name": "tcc", "variable": "tcc"},
+            ],
+        }
+    )
+    written = obs.run(config)
+    assert [p.name for p in written] == ["analysis.nc"] * 4
+    assert {p.parent.name for p in written} == {"t2m", "precip6h", "ws10m", "tcc"}
+
+    # Readable by the bris verif source, with the expected values and units
+    src = sources.Verif(str(tmp_path / "out" / "t2m" / "analysis.nc"))
+    locations = src.locations
+    assert len(locations) == 25
+    assert src.units == "degC"
+    start = 1672552800  # 2023-01-01T06
+    result = src.get("2t", start, start + 12 * 3600, 6 * 3600)
+    data = result.get_data("2t", start)
+    # location ids index the cropped grid; recover global indices from lat/lon to check values
+    lat = np.array([loc.lat for loc in locations])
+    lon = np.array([loc.lon for loc in locations])
+    gi = (np.round(lat + 10) * 21 + np.round(lon)).astype(int)
+    np.testing.assert_allclose(data, 273.15 + 0.01 * gi + 1.0 - 273.15, atol=1e-3)
+    np.testing.assert_allclose([loc.elev for loc in locations], 100.0 * (gi % 7), atol=1e-3)
+
+    tp = sources.Verif(str(tmp_path / "out" / "precip6h" / "analysis.nc"))
+    assert tp.units == "mm"
+    np.testing.assert_allclose(tp.get("tp", start, start, 3600).get_data("tp", start), 1.0 * (gi % 5), atol=1e-3)
+
+    ws = sources.Verif(str(tmp_path / "out" / "ws10m" / "analysis.nc"))
+    assert ws.units == "m/s"
+    np.testing.assert_allclose(ws.get("ws", start, start, 3600).get_data("ws", start), np.hypot(4.0, 4.0), atol=1e-3)
+
+    tcc = sources.Verif(str(tmp_path / "out" / "tcc" / "analysis.nc"))
+    np.testing.assert_allclose(tcc.get("tcc", start, start, 3600).get_data("tcc", start), 0.6, atol=1e-3)
+    assert len(tcc.file["time"]) == 3
+
+
+def test_run_rejects_mismatched_grid(tmp_path, stores, grid):
+    lat, lon = grid
+    other = _make_zarr(
+        tmp_path / "other.zarr", ["tcc"], lat + 1.0, lon, stores["dates"],
+        np.zeros((len(stores["dates"]), 1, 1, len(lat)), np.float32),
+    )
+    config = OmegaConf.create(
+        {
+            "start_date": "2023-01-01T00:00:00", "end_date": "2023-01-01T18:00:00",
+            "output": str(tmp_path / "{name}.nc"), "datasets": [stores["main"], other],
+            "outputs": [{"name": "tcc", "variable": "tcc"}],
+        }
+    )
+    with pytest.raises(ValueError, match="latitudes"):
+        obs.run(config)
+
+
+def test_main_cli(tmp_path, stores):
+    cfg = tmp_path / "obs.yaml"
+    OmegaConf.save(
+        OmegaConf.create(
+            {
+                "start_date": "2023-01-01T00:00:00",
+                "end_date": "2023-01-01T18:00:00",
+                "output": str(tmp_path / "cli" / "{name}.nc"),
+                "points": {"every": 50},
+                "datasets": [stores["main"]],
+                "outputs": [{"name": "t2m", "variable": "2t", "units": "degC"}],
+            }
+        ),
+        cfg,
+    )
+    assert obs.main(["--config", str(cfg), "-sd", "2023-01-01T12:00:00"]) == 0
+    src = sources.Verif(str(tmp_path / "cli" / "t2m.nc"))
+    assert len(src.file["time"]) == 2  # start override applied: 12 and 18 UTC
+    assert len(src.locations) == stores["n"] // 50 + 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -59,3 +59,10 @@ def test_create_config():
     assert config is not None
     assert hasattr(config, "start_date")
     assert config["start_date"] == "2022-01-01T12:34:56"
+
+    # Dotted override (as produced by `bris -l 3`) must reach the nested key
+    config = bris.utils.create_config(
+        "config/tox_test_inference.yaml", {"checkpoints.forecaster.leadtimes": 3}
+    )
+    assert config.checkpoints.forecaster.leadtimes == 3
+    assert "checkpoints.forecaster.leadtimes" not in config

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -66,3 +66,11 @@ def test_create_config():
     )
     assert config.checkpoints.forecaster.leadtimes == 3
     assert "checkpoints.forecaster.leadtimes" not in config
+
+    # String overrides keep their type even when they look like numbers
+    config = bris.utils.create_config(
+        "config/tox_test_inference.yaml",
+        {"frequency": "21600", "start_date": "20220101"},
+    )
+    assert config.frequency == "21600" and isinstance(config.frequency, str)
+    assert config.start_date == "20220101" and isinstance(config.start_date, str)


### PR DESCRIPTION
New command `bris-obs --config obs.yaml` that extracts a subset of grid points from analysis zarr stores over a period and writes one Verif file per variable (time x location), readable by the `verif` observation source of the verif output. This allows verifying forecasts against analyses at a subset of points without reading the full dataset at inference time (the anemoidataset source reads the zarr through anemoi-datasets' area crop at finalize, which costs ~1 minute per timestep and variable on large grids).

- Zarr stores are read directly, decompressing each chunk once per timestep for all variables in it; optional worker pool.
- Extra stores may supply variables missing from the first one (same grid and dates, checked), e.g. cloud fractions.
- Point selection: nearest grid point to each node of a regular lat/lon grid (`spacing`), or every n-th point (`every`, warns about aliasing on reduced Gaussian grids), optionally inside an [N, W, S, E] area.
- Units converted with bris.units from the anemoi units; derived wind speed from 10u/10v; altitudes from z.
- Template config and tests on a synthetic zarr store.